### PR TITLE
Prevent direct access to PHP files to avoid PHP errors

### DIFF
--- a/postratings-manager.php
+++ b/postratings-manager.php
@@ -16,6 +16,8 @@
 +----------------------------------------------------------------+
 */
 
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 ### Check Whether User Can Manage Ratings
 if(!current_user_can('manage_ratings')) {

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -16,6 +16,8 @@
 +----------------------------------------------------------------+
 */
 
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 ### Check Whether User Can Manage Ratings
 if(!current_user_can('manage_ratings')) {

--- a/postratings-stats.php
+++ b/postratings-stats.php
@@ -16,6 +16,8 @@
 +----------------------------------------------------------------+
 */
 
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 ### Function: Display Most Rated Page/Post
 if(!function_exists('get_most_rated')) {

--- a/postratings-templates.php
+++ b/postratings-templates.php
@@ -16,6 +16,8 @@
 +----------------------------------------------------------------+
 */
 
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 ### Check Whether User Can Manage Ratings
 if(!current_user_can('manage_ratings')) {

--- a/postratings-uninstall.php
+++ b/postratings-uninstall.php
@@ -16,6 +16,8 @@
 +----------------------------------------------------------------+
 */
 
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 ### Check Whether User Can Manage Ratings
 if(!current_user_can('manage_ratings')) {

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -28,6 +28,8 @@ Text Domain: wp-postratings
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 ### Define Image Extension
 define('RATINGS_IMG_EXT', 'gif');


### PR DESCRIPTION
Most hosts allow direct access to all WordPress / plugin PHP files, when of course in reality, people only need to directly access files such as index.php, admin-ajax.php, and so on.

This pull requests adds a simple ABSPATH check to the top of each PHP file (as used by many plugins, including bbPress and BuddyPress) which terminates execution if the file is accessed directly outside of WordPress. Same behaviour as now, but it prevents PHP Fatal Errors in the server's log :)
