### PR TITLE
Corrects typo made in 0212ecb.

### DIFF
--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -627,7 +627,7 @@ function process_ratings() {
 						$rate_cookie = setcookie("rated_".$post_id, $ratings_value[$rate-1], time() + 30000000, COOKIEPATH);
 					}
 					// Log Ratings No Matter What
-					$rate_log = $wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->ratings} (%d, %d, %s, %d, NOW(), %s, %s, %s, %d )" ), 0, $post_id, $post_title, $ratings_value[$rate-1], get_ipaddress(), @gethostbyaddr( get_ipaddress() ), $rate_user, $rate_userid );
+					$rate_log = $wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->ratings} (%d, %d, %s, %d, NOW(), %s, %s, %s, %d )", 0, $post_id, $post_title, $ratings_value[$rate-1], get_ipaddress(), @gethostbyaddr( get_ipaddress() ), $rate_user, $rate_userid ) );
 					// Allow Other Plugins To Hook When A Post Is Rated
 					do_action('rate_post', $rate_userid, $post_id, $ratings_value[$rate-1]);
 					// Output AJAX Result


### PR DESCRIPTION
Misplaced the bracket in the above commit, which was valid PHP but caused the following deprecated function notice in WordPress:

[09-Jun-2013 13:52:22 UTC] PHP Warning:  Missing argument 2 for wpdb::prepare(), called in /Users/paul/Sites/master/wp-content/plugins/wp-postratings/wp-postratings.php on line 630 and defined in /Users/paul/Sites/example.com/wp-includes/wp-db.php on line 990
