### PR TITLE
get_comment_authors_ratings fix when global variable post is not set

### DIFF
--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -332,9 +332,10 @@ function check_rated_username($post_id) {
 add_action('loop_start', 'get_comment_authors_ratings');
 function get_comment_authors_ratings() {
 	global $wpdb, $post, $comment_authors_ratings;
+	$comment_authors_ratings_results = null;
 	if(!is_feed() && !is_admin()) {
 		$comment_authors_ratings = array();
-		if($post->ID) {
+		if($post && $post->ID) {
 			$comment_authors_ratings_results = $wpdb->get_results( $wpdb->prepare( "SELECT rating_username, rating_rating, rating_ip FROM {$wpdb->ratings} WHERE rating_postid = %d", $post->ID ) );
 		}
 		if($comment_authors_ratings_results) {


### PR DESCRIPTION
I had a problem when I used template_redirect hook and was getting to the loop without global $post being set.
I got a notice about that. This is the way I suggest to fix it since this function is called on loop_start.
