### PR TITLE
Allow use inside custom Schema code

### DIFF
--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1262,7 +1262,7 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
 		$ratings_meta .= '<meta itemprop="ratingCount" content="'.$post_ratings_users.'" />';
 		$ratings_meta .= '</div>';
 		
-		$value = ($itemtype != '' )?$value.$post_meta.$ratings_meta:$value.$ratings_meta;
+		$value = empty( $itemtype ) ? $value . $ratings_meta : $value . $post_meta . $ratings_meta;
 	}
 
 	return apply_filters('expand_ratings_template', $value);

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1261,8 +1261,8 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
 		$ratings_meta .= '<meta itemprop="ratingValue" content="'.$post_ratings_average.'" />';
 		$ratings_meta .= '<meta itemprop="ratingCount" content="'.$post_ratings_users.'" />';
 		$ratings_meta .= '</div>';
-
-		$value = $value.$post_meta.$ratings_meta;
+		
+		$value = ($itemtype != '' )?$value.$post_meta.$ratings_meta:$value.$ratings_meta;
 	}
 
 	return apply_filters('expand_ratings_template', $value);


### PR DESCRIPTION
I wanted to use the plugin in a website where I already have schema code, but the plugin was duplicating the schema object, so I set the $itemtype = ' ' with wp_postratings_schema_itemtype filter 
Now I had 1 Schema object, but with duplicates values for title, link, description
so I update the code with a minuscule condition: if $itemtype is not set, don't even echo the meta. (because you already had it defined in your template).