### PR TITLE
Add Post ID to wp_postratings_check_rated filter

### DIFF
--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -298,7 +298,7 @@ function check_rated( $post_id ) {
 			break;
 	}
 
-	$rated = apply_filters( 'wp_postratings_check_rated', $rated );
+	$rated = apply_filters( 'wp_postratings_check_rated', $rated, $post_id );
 
 	return $rated;
 }


### PR DESCRIPTION
Without the Post ID provided in the filter for the `check_rated` function it's mostly impossible to make any useful decisions about how to handle the filtered data.

In some contexts it is possible to just use `$_REQUEST['pid']` or `get_the_ID()` but for many cases it's not possible to know the Post ID that is being checked. Adding the `$post_id` var to the filter makes it clear which post is being checked every time.