### PR TITLE
Show all posts when sorting by rating

### DIFF
--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -772,12 +772,7 @@ function ratings_most_fields($content) {
 }
 function ratings_most_join($content) {
 	global $wpdb;
-	$content .= " LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID";
-	return $content;
-}
-function ratings_most_where($content) {
-	global $wpdb;
-	$content .= " AND $wpdb->postmeta.meta_key = 'ratings_users'";
+	$content .= " LEFT JOIN $wpdb->postmeta ON $wpdb->postmeta.post_id = $wpdb->posts.ID AND $wpdb->postmeta.meta_key = 'ratings_users'";
 	return $content;
 }
 function ratings_most_orderby($content) {
@@ -797,17 +792,16 @@ function ratings_highest_fields($content) {
 }
 function ratings_highest_join($content) {
 	global $wpdb;
-	$content .= " LEFT JOIN $wpdb->postmeta AS t1 ON t1.post_id = $wpdb->posts.ID LEFT JOIN $wpdb->postmeta As t2 ON t1.post_id = t2.post_id";
-	return $content;
-}
-function ratings_highest_where($content) {
 	$ratings_max = intval(get_option('postratings_max'));
 	$ratings_custom = intval(get_option('postratings_customrating'));
+
+	$content .= " LEFT JOIN $wpdb->postmeta AS t1 ON t1.post_id = $wpdb->posts.ID";
 	if($ratings_custom && $ratings_max == 2) {
-		$content .= " AND t1.meta_key = 'ratings_score' AND t2.meta_key = 'ratings_users'";
+		$content .= " AND t1.meta_key = 'ratings_score'";
 	} else {
-		$content .= " AND t1.meta_key = 'ratings_average' AND t2.meta_key = 'ratings_users'";
+		$content .= " AND t1.meta_key = 'ratings_average'";
 	}
+	$content .= " LEFT JOIN $wpdb->postmeta As t2 ON t1.post_id = t2.post_id AND t2.meta_key = 'ratings_users'";
 	return $content;
 }
 function ratings_highest_orderby($content) {
@@ -835,29 +829,23 @@ function ratings_sorting($local_wp_query) {
 	if($local_wp_query->get('r_sortby') == 'most_rated') {
 		add_filter('posts_fields', 'ratings_most_fields');
 		add_filter('posts_join', 'ratings_most_join');
-		add_filter('posts_where', 'ratings_most_where');
 		add_filter('posts_orderby', 'ratings_most_orderby');
 		remove_filter('posts_fields', 'ratings_highest_fields');
 		remove_filter('posts_join', 'ratings_highest_join');
-		remove_filter('posts_where', 'ratings_highest_where');
 		remove_filter('posts_orderby', 'ratings_highest_orderby');
 	} elseif($local_wp_query->get('r_sortby') == 'highest_rated') {
 		add_filter('posts_fields', 'ratings_highest_fields');
 		add_filter('posts_join', 'ratings_highest_join');
-		add_filter('posts_where', 'ratings_highest_where');
 		add_filter('posts_orderby', 'ratings_highest_orderby');
 		remove_filter('posts_fields', 'ratings_most_fields');
 		remove_filter('posts_join', 'ratings_most_join');
-		remove_filter('posts_where', 'ratings_most_where');
 		remove_filter('posts_orderby', 'ratings_most_orderby');
 	} else {
 		remove_filter('posts_fields', 'ratings_highest_fields');
 		remove_filter('posts_join', 'ratings_highest_join');
-		remove_filter('posts_where', 'ratings_highest_where');
 		remove_filter('posts_orderby', 'ratings_highest_orderby');
 		remove_filter('posts_fields', 'ratings_most_fields');
 		remove_filter('posts_join', 'ratings_most_join');
-		remove_filter('posts_where', 'ratings_most_where');
 		remove_filter('posts_orderby', 'ratings_most_orderby');
 	}
 }


### PR DESCRIPTION
I ran into an issue where sorting by rating on a tags page (e.g. using `?tag=foo&r_sortby=highest_rated`) would not show any unrated posts. This pull request should fix that by moving the `meta_key` check into the join rather than the `WHERE` clause.