### PR TITLE
Security hardening

### DIFF
--- a/includes/postratings-admin.php
+++ b/includes/postratings-admin.php
@@ -94,7 +94,7 @@ class WPPostRatingsAdmin {
 	 */
 	function postrating_admin_column_title( $defaults ) {
 
-		$defaults['ratings'] = __( 'Ratings', 'wp-postratings' );
+		$defaults['ratings'] = esc_html__( 'Ratings', 'wp-postratings' );
 		return $defaults;
 
 	}

--- a/includes/postratings-shortcodes.php
+++ b/includes/postratings-shortcodes.php
@@ -27,7 +27,7 @@ function ratings_shortcode( $atts ) {
             return the_ratings( 'span', $id, false );
         }
     } else {
-        return __( 'Note: There is a rating embedded within this post, please visit this post to rate it.', 'wp-postratings' );
+        return esc_html__( 'Note: There is a rating embedded within this post, please visit this post to rate it.', 'wp-postratings' );
     }
 }
 add_shortcode( 'ratings', 'ratings_shortcode' );

--- a/includes/postratings-stats.php
+++ b/includes/postratings-stats.php
@@ -58,7 +58,7 @@ if(!function_exists('get_most_rated')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -117,7 +117,7 @@ if(!function_exists('get_most_rated_category')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -170,7 +170,7 @@ if(!function_exists('get_most_rated_range')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -230,7 +230,7 @@ if(!function_exists('get_most_rated_range_category')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -283,7 +283,7 @@ if(!function_exists('get_highest_rated')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -343,7 +343,7 @@ if(!function_exists('get_highest_rated_category')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -396,7 +396,7 @@ if(!function_exists('get_highest_rated_range')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -456,7 +456,7 @@ if(!function_exists('get_highest_rated_range_category')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -509,7 +509,7 @@ if(!function_exists('get_lowest_rated')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -569,7 +569,7 @@ if(!function_exists('get_lowest_rated_category')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -622,7 +622,7 @@ if(!function_exists('get_lowest_rated_range')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -667,7 +667,7 @@ if(!function_exists('get_highest_score')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -719,7 +719,7 @@ if(!function_exists('get_highest_score_category')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -765,7 +765,7 @@ if(!function_exists('get_highest_score_range')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -818,7 +818,7 @@ if(!function_exists('get_highest_score_range_category')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -877,7 +877,7 @@ if(!function_exists('get_highest_rated_tag')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;
@@ -936,7 +936,7 @@ if(!function_exists('get_lowest_rated_tag')) {
 				$output .= expand_ratings_template($temp, $post, null, $chars, false)."\n";
 			}
 		} else {
-			$output = '<li>'.__('N/A', 'wp-postratings').'</li>'."\n";
+			$output = '<li>'.esc_html__('N/A', 'wp-postratings').'</li>'."\n";
 		}
 		if($display) {
 			echo $output;

--- a/includes/postratings-widgets.php
+++ b/includes/postratings-widgets.php
@@ -23,9 +23,9 @@ class WP_Widget_PostRatings extends WP_Widget {
     function __construct() {
         parent::__construct(
 			'ratings-widget',
-			__('Ratings', 'wp-postratings'),
+			esc_html__('Ratings', 'wp-postratings'),
 			array(
-				'description' => __('WP-PostRatings ratings statistics', 'wp-postratings')
+				'description' => esc_html__('WP-PostRatings ratings statistics', 'wp-postratings')
 			)
 		);
     }
@@ -113,7 +113,7 @@ class WP_Widget_PostRatings extends WP_Widget {
     // Display Widget Control Form
     function form($instance) {
         global $wpdb;
-        $instance = wp_parse_args((array) $instance, array('title' => __('Ratings', 'wp-postratings'), 'type' => 'highest_rated', 'mode' => '', 'limit' => 10, 'min_votes' => 0, 'chars' => 200, 'cat_ids' => '0', 'time_range' => '1 day'));
+        $instance = wp_parse_args((array) $instance, array('title' => esc_html__('Ratings', 'wp-postratings'), 'type' => 'highest_rated', 'mode' => '', 'limit' => 10, 'min_votes' => 0, 'chars' => 200, 'cat_ids' => '0', 'time_range' => '1 day'));
         $title = esc_attr($instance['title']);
         $type = esc_attr($instance['type']);
         $mode = trim( esc_attr( $instance['mode'] ) );
@@ -127,70 +127,70 @@ class WP_Widget_PostRatings extends WP_Widget {
         ) );
 ?>
         <p>
-            <label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:', 'wp-postratings'); ?></label>
+            <label for="<?php echo $this->get_field_id('title'); ?>"><?php esc_html_e('Title:', 'wp-postratings'); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo $title; ?>" />
         </p>
         <p>
-            <label for="<?php echo $this->get_field_id('type'); ?>"><?php _e('Statistics Type:', 'wp-postratings'); ?></label>
+            <label for="<?php echo $this->get_field_id('type'); ?>"><?php esc_html_e('Statistics Type:', 'wp-postratings'); ?></label>
 			<select name="<?php echo $this->get_field_name('type'); ?>" id="<?php echo $this->get_field_id('type'); ?>" class="widefat">
-				<option value="most_rated"<?php selected('most_rated', $type); ?>><?php _e('Most Rated', 'wp-postratings'); ?></option>
-				<option value="most_rated_category"<?php selected('most_rated_category', $type); ?>><?php _e('Most Rated By Category', 'wp-postratings'); ?></option>
-				<option value="most_rated_range"<?php selected('most_rated_range', $type); ?>><?php _e('Most Rated By Time Range', 'wp-postratings'); ?></option>
-				<option value="most_rated_range_category"<?php selected('most_rated_range_category', $type); ?>><?php _e('Most Rated By Time Range And Category', 'wp-postratings'); ?></option>
+				<option value="most_rated"<?php selected('most_rated', $type); ?>><?php esc_html_e('Most Rated', 'wp-postratings'); ?></option>
+				<option value="most_rated_category"<?php selected('most_rated_category', $type); ?>><?php esc_html_e('Most Rated By Category', 'wp-postratings'); ?></option>
+				<option value="most_rated_range"<?php selected('most_rated_range', $type); ?>><?php esc_html_e('Most Rated By Time Range', 'wp-postratings'); ?></option>
+				<option value="most_rated_range_category"<?php selected('most_rated_range_category', $type); ?>><?php esc_html_e('Most Rated By Time Range And Category', 'wp-postratings'); ?></option>
 				<optgroup>&nbsp;</optgroup>
-				<option value="highest_rated"<?php selected('highest_rated', $type); ?>><?php _e('Highest Rated', 'wp-postratings'); ?></option>
-				<option value="highest_rated_category"<?php selected('highest_rated_category', $type); ?>><?php _e('Highest Rated By Category', 'wp-postratings'); ?></option>
-				<option value="highest_rated_range"<?php selected('highest_rated_range', $type); ?>><?php _e('Highest Rated By Time Range', 'wp-postratings'); ?></option>
-				<option value="highest_rated_range_category"<?php selected('highest_rated_range_category', $type); ?>><?php _e('Highest Rated By Time Range And Category', 'wp-postratings'); ?></option>
+				<option value="highest_rated"<?php selected('highest_rated', $type); ?>><?php esc_html_e('Highest Rated', 'wp-postratings'); ?></option>
+				<option value="highest_rated_category"<?php selected('highest_rated_category', $type); ?>><?php esc_html_e('Highest Rated By Category', 'wp-postratings'); ?></option>
+				<option value="highest_rated_range"<?php selected('highest_rated_range', $type); ?>><?php esc_html_e('Highest Rated By Time Range', 'wp-postratings'); ?></option>
+				<option value="highest_rated_range_category"<?php selected('highest_rated_range_category', $type); ?>><?php esc_html_e('Highest Rated By Time Range And Category', 'wp-postratings'); ?></option>
 				<optgroup>&nbsp;</optgroup>
-				<option value="lowest_rated"<?php selected('lowest_rated', $type); ?>><?php _e('Lowest Rated', 'wp-postratings'); ?></option>
-				<option value="lowest_rated_category"<?php selected('lowest_rated_category', $type); ?>><?php _e('Lowest Rated By Category', 'wp-postratings'); ?></option>
-				<option value="lowest_rated_range"<?php selected('lowest_rated_range', $type); ?>><?php _e('Lowest Rated By Time Range', 'wp-postratings'); ?></option>
+				<option value="lowest_rated"<?php selected('lowest_rated', $type); ?>><?php esc_html_e('Lowest Rated', 'wp-postratings'); ?></option>
+				<option value="lowest_rated_category"<?php selected('lowest_rated_category', $type); ?>><?php esc_html_e('Lowest Rated By Category', 'wp-postratings'); ?></option>
+				<option value="lowest_rated_range"<?php selected('lowest_rated_range', $type); ?>><?php esc_html_e('Lowest Rated By Time Range', 'wp-postratings'); ?></option>
 				<optgroup>&nbsp;</optgroup>
-				<option value="highest_score"<?php selected('highest_score', $type); ?>><?php _e('Highest Score', 'wp-postratings'); ?></option>
-				<option value="highest_score_category"<?php selected('highest_score_category', $type); ?>><?php _e('Highest Score By Category', 'wp-postratings'); ?></option>
-				<option value="highest_score_range"<?php selected('highest_score_range', $type); ?>><?php _e('Highest Score By Time Range', 'wp-postratings'); ?></option>
-				<option value="highest_score_range_category"<?php selected('highest_score_range_category', $type); ?>><?php _e('Highest Score By Time Range And Category', 'wp-postratings'); ?></option>
+				<option value="highest_score"<?php selected('highest_score', $type); ?>><?php esc_html_e('Highest Score', 'wp-postratings'); ?></option>
+				<option value="highest_score_category"<?php selected('highest_score_category', $type); ?>><?php esc_html_e('Highest Score By Category', 'wp-postratings'); ?></option>
+				<option value="highest_score_range"<?php selected('highest_score_range', $type); ?>><?php esc_html_e('Highest Score By Time Range', 'wp-postratings'); ?></option>
+				<option value="highest_score_range_category"<?php selected('highest_score_range_category', $type); ?>><?php esc_html_e('Highest Score By Time Range And Category', 'wp-postratings'); ?></option>
 			</select>
         </p>
         <p>
-            <label for="<?php echo $this->get_field_id('mode'); ?>"><?php _e('Include Ratings From:', 'wp-postratings'); ?></label>
+            <label for="<?php echo $this->get_field_id('mode'); ?>"><?php esc_html_e('Include Ratings From:', 'wp-postratings'); ?></label>
 			<select name="<?php echo $this->get_field_name('mode'); ?>" id="<?php echo $this->get_field_id('mode'); ?>" class="widefat">
-				<option value=""<?php selected( '', $mode ); ?>><?php _e( 'All', 'wp-postratings' ); ?></option>
+				<option value=""<?php selected( '', $mode ); ?>><?php esc_html_e( 'All', 'wp-postratings' ); ?></option>
 					<?php if( $post_types > 0 ): ?>
 						<?php foreach( $post_types as $post_type ): ?>
-							<option value="<?php echo $post_type; ?>"<?php selected( $post_type, $mode ); ?>><?php printf( __( '%s Only', 'wp-postratings' ), ucfirst( $post_type ) ); ?></option>
+							<option value="<?php echo $post_type; ?>"<?php selected( $post_type, $mode ); ?>><?php printf( esc_html__( '%s Only', 'wp-postratings' ), ucfirst( $post_type ) ); ?></option>
 						<?php endforeach; ?>
 					<?php endif; ?>
 			</select>
         </p>
         <p>
-            <label for="<?php echo $this->get_field_id('limit'); ?>"><?php _e('No. Of Records To Show:', 'wp-postratings'); ?></label>
+            <label for="<?php echo $this->get_field_id('limit'); ?>"><?php esc_html_e('No. Of Records To Show:', 'wp-postratings'); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('limit'); ?>" name="<?php echo $this->get_field_name('limit'); ?>" type="text" value="<?php echo $limit; ?>" />
         </p>
         <p>
-            <label for="<?php echo $this->get_field_id('min_votes'); ?>"><?php _e('Minimum Votes:', 'wp-postratings'); ?> <span style="color: red;">*</span></label>
+            <label for="<?php echo $this->get_field_id('min_votes'); ?>"><?php esc_html_e('Minimum Votes:', 'wp-postratings'); ?> <span style="color: red;">*</span></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('min_votes'); ?>" name="<?php echo $this->get_field_name('min_votes'); ?>" type="text" value="<?php echo $min_votes; ?>" size="4" />
-            <span class="description"><?php _e('The minimum number of votes, before the rating displayed.', 'wp-postratings'); ?></span>
+            <span class="description"><?php esc_html_e('The minimum number of votes, before the rating displayed.', 'wp-postratings'); ?></span>
         </p>
         <p>
-            <label for="<?php echo $this->get_field_id('chars'); ?>"><?php _e('Maximum Title Length (Characters):', 'wp-postratings'); ?></label>
+            <label for="<?php echo $this->get_field_id('chars'); ?>"><?php esc_html_e('Maximum Title Length (Characters):', 'wp-postratings'); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('chars'); ?>" name="<?php echo $this->get_field_name('chars'); ?>" type="text" value="<?php echo $chars; ?>" />
-            <span class="description"><?php _e('<strong>0</strong> to disable.', 'wp-postratings'); ?></span>
+            <span class="description"><?php esc_html_e('<strong>0</strong> to disable.', 'wp-postratings'); ?></span>
         </p>
         <p>
-            <label for="<?php echo $this->get_field_id('cat_ids'); ?>"><?php _e('Category IDs:', 'wp-postratings'); ?> <span style="color: red;">**</span></label>
+            <label for="<?php echo $this->get_field_id('cat_ids'); ?>"><?php esc_html_e('Category IDs:', 'wp-postratings'); ?> <span style="color: red;">**</span></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('cat_ids'); ?>" name="<?php echo $this->get_field_name('cat_ids'); ?>" type="text" value="<?php echo $cat_ids; ?>" />
-            <span class="description"><?php _e('Seperate mutiple categories with commas.', 'wp-postratings'); ?></span>
+            <span class="description"><?php esc_html_e('Seperate mutiple categories with commas.', 'wp-postratings'); ?></span>
         </p>
         <p>
-            <label for="<?php echo $this->get_field_id('time_range'); ?>"><?php _e('Time Range:', 'wp-postratings'); ?> <span style="color: red;">**</span></label>
+            <label for="<?php echo $this->get_field_id('time_range'); ?>"><?php esc_html_e('Time Range:', 'wp-postratings'); ?> <span style="color: red;">**</span></label>
 			<input class="widefat" id="<?php echo $this->get_field_id('time_range'); ?>" name="<?php echo $this->get_field_name('time_range'); ?>" type="text" value="<?php echo $time_range; ?>" />
-            <span class="description"><?php _e('Use values like <strong>1 day</strong>, <strong>2 weeks</strong>, <strong>1 month</strong>.', 'wp-postratings'); ?></span>
+            <span class="description"><?php esc_html_e('Use values like <strong>1 day</strong>, <strong>2 weeks</strong>, <strong>1 month</strong>.', 'wp-postratings'); ?></span>
         </p>
         <p style="color: red;">
-            <span class="description"><?php _e('* Time range statistics does not support Minimum Votes field, you can ignore that it.', 'wp-postratings'); ?></span><br />
-            <span class="description"><?php _e('** If you are not using any category or time range statistics, you can ignore it.', 'wp-postratings'); ?></span>
+            <span class="description"><?php esc_html_e('* Time range statistics does not support Minimum Votes field, you can ignore that it.', 'wp-postratings'); ?></span><br />
+            <span class="description"><?php esc_html_e('** If you are not using any category or time range statistics, you can ignore it.', 'wp-postratings'); ?></span>
         <p>
         <input type="hidden" id="<?php echo $this->get_field_id('submit'); ?>" name="<?php echo $this->get_field_name('submit'); ?>" value="1" />
 <?php

--- a/includes/postratings-widgets.php
+++ b/includes/postratings-widgets.php
@@ -38,7 +38,7 @@ class WP_Widget_PostRatings extends WP_Widget {
         $limit = intval($instance['limit']);
         $min_votes = intval($instance['min_votes']);
         $chars = intval($instance['chars']);
-        $cat_ids = explode(',', esc_attr($instance['cat_ids']));
+        $cat_ids = array_map( 'intval', explode(',', esc_attr($instance['cat_ids'])) );
         $time_range = esc_attr($instance['time_range']);
         echo $args['before_widget'].$args['before_title'].$title.$args['after_title'];
         echo '<ul>'."\n";

--- a/postratings-manager.php
+++ b/postratings-manager.php
@@ -30,7 +30,7 @@ $base_page                  = admin_url( 'admin.php?page=' . urlencode( $base_na
 $postratings_sort_url       = '';
 $postratings_sortby_text    = '';
 $postratings_sortorder_text = '';
-$ratings_image              = get_option( 'postratings_image' );
+$ratings_image              = sanitize_file_name( get_option( 'postratings_image' ) );
 $ratings_max                = intval( get_option( 'postratings_max' ) );
 
 // Handle $_GET values

--- a/postratings-manager.php
+++ b/postratings-manager.php
@@ -77,17 +77,17 @@ if ( ! empty( $_POST['do'] ) ) {
 			if($post_ids == 'all') {
 				$delete_logs = $wpdb->query("DELETE FROM $wpdb->ratings");
 				if($delete_logs) {
-					$text = '<p style="color: green;">'.__('All Rating Logs Have Been Deleted.', 'wp-postratings').'</p>';
+					$text = '<p style="color: green;">'.esc_html__('All Rating Logs Have Been Deleted.', 'wp-postratings').'</p>';
 				} else {
-					$text = '<p style="color: red;">'.__('An Error Has Occured While Deleting All Rating Logs.', 'wp-postratings').'</p>';
+					$text = '<p style="color: red;">'.esc_html__('An Error Has Occured While Deleting All Rating Logs.', 'wp-postratings').'</p>';
 				}
 
 			} else {
 				$delete_logs = $wpdb->query( "DELETE FROM {$wpdb->ratings} WHERE rating_postid IN (" . $post_ids . ')' );
 				if($delete_logs) {
-					$text = '<p style="color: green;">'.sprintf(__('All Rating Logs For Post ID(s) %s Have Been Deleted.', 'wp-postratings'), $post_ids).'</p>';
+					$text = '<p style="color: green;">'.sprintf(esc_html__('All Rating Logs For Post ID(s) %s Have Been Deleted.', 'wp-postratings'), $post_ids).'</p>';
 				} else {
-					$text = '<p style="color: red;">'.sprintf(__('An Error Has Occured While Deleting All Rating Logs For Post ID(s) %s.', 'wp-postratings'), $post_ids).'</p>';
+					$text = '<p style="color: red;">'.sprintf(esc_html__('An Error Has Occured While Deleting All Rating Logs For Post ID(s) %s.', 'wp-postratings'), $post_ids).'</p>';
 				}
 			}
 			break;
@@ -97,7 +97,7 @@ if ( ! empty( $_POST['do'] ) ) {
 			if($post_ids == 'all') {
 				foreach($ratings_postmeta as $postmeta) {
 					$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s", $postmeta ) );
-					$text .= '<p style="color: green;">'.sprintf(__('Rating Data "%s" Has Been Deleted.', 'wp-postratings'), "<strong><em>$postmeta</em></strong>").'</p>';
+					$text .= '<p style="color: green;">'.sprintf(esc_html__('Rating Data "%s" Has Been Deleted.', 'wp-postratings'), "<strong><em>$postmeta</em></strong>").'</p>';
 				}
 
 			} else {
@@ -105,7 +105,7 @@ if ( ! empty( $_POST['do'] ) ) {
 					foreach( $ratings_postmeta as $meta_key ) {
 						delete_post_meta( $the_post_id, $meta_key );
 
-						$text .= '<p style="color: green;">'.sprintf(__('Rating Data "%s" For Post ID(s) %s Has Been Deleted.', 'wp-postratings'), "<strong><em>$meta_key</em></strong>", $post_ids).'</p>';
+						$text .= '<p style="color: green;">'.sprintf(esc_html__('Rating Data "%s" For Post ID(s) %s Has Been Deleted.', 'wp-postratings'), "<strong><em>$meta_key</em></strong>", $post_ids).'</p>';
 					}
 				}
 			}
@@ -115,30 +115,30 @@ if ( ! empty( $_POST['do'] ) ) {
 			if($post_ids == 'all') {
 				$delete_logs = $wpdb->query("DELETE FROM $wpdb->ratings");
 				if($delete_logs) {
-					$text = '<p style="color: green;">'.__('All Rating Logs Have Been Deleted.', 'wp-postratings').'</p>';
+					$text = '<p style="color: green;">'.esc_html__('All Rating Logs Have Been Deleted.', 'wp-postratings').'</p>';
 				} else {
-					$text = '<p style="color: red;">'.__('An Error Has Occured While Deleting All Rating Logs.', 'wp-postratings').'</p>';
+					$text = '<p style="color: red;">'.esc_html__('An Error Has Occured While Deleting All Rating Logs.', 'wp-postratings').'</p>';
 				}
 
 				// @todo Deleting meta records like will not clear the post's object cache
 				foreach($ratings_postmeta as $postmeta) {
 					$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s", $postmeta ) );
-					$text .= '<p style="color: green;">'.sprintf(__('Rating Data "%s" Has Been Deleted.', 'wp-postratings'), "<strong><em>$postmeta</em></strong>").'</p>';
+					$text .= '<p style="color: green;">'.sprintf(esc_html__('Rating Data "%s" Has Been Deleted.', 'wp-postratings'), "<strong><em>$postmeta</em></strong>").'</p>';
 				}
 
 			} else {
 				$delete_logs = $wpdb->query( "DELETE FROM {$wpdb->ratings} WHERE rating_postid IN (" . $post_ids . ')' );
 				if($delete_logs) {
-					$text = '<p style="color: green;">'.sprintf(__('All Rating Logs For Post ID(s) %s Have Been Deleted.', 'wp-postratings'), $post_ids).'</p>';
+					$text = '<p style="color: green;">'.sprintf(esc_html__('All Rating Logs For Post ID(s) %s Have Been Deleted.', 'wp-postratings'), $post_ids).'</p>';
 				} else {
-					$text = '<p style="color: red;">'.sprintf(__('An Error Has Occured While Deleting All Rating Logs For Post ID(s) %s.', 'wp-postratings'), $post_ids).'</p>';
+					$text = '<p style="color: red;">'.sprintf(esc_html__('An Error Has Occured While Deleting All Rating Logs For Post ID(s) %s.', 'wp-postratings'), $post_ids).'</p>';
 				}
 
 				foreach ( $post_ids_list as $the_post_id ) {
 					foreach( $ratings_postmeta as $meta_key ) {
 						delete_post_meta( $the_post_id, $meta_key );
 
-						$text .= '<p style="color: green;">'.sprintf(__('Rating Data "%s" For Post ID(s) %s Has Been Deleted.', 'wp-postratings'), "<strong><em>$meta_key</em></strong>", $post_ids).'</p>';
+						$text .= '<p style="color: green;">'.sprintf(esc_html__('Rating Data "%s" For Post ID(s) %s Has Been Deleted.', 'wp-postratings'), "<strong><em>$meta_key</em></strong>", $post_ids).'</p>';
 					}
 				}
 			}
@@ -259,11 +259,11 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 <?php if(!empty($text)) { echo '<!-- Last Action --><div id="message" class="updated fade"><p>'.$text.'</p></div>'; } ?>
 <!-- Manage Post Ratings -->
 <div class="wrap">
-	<h1><?php _e('Manage Ratings', 'wp-postratings'); ?></h1>
-	<h2><?php _e('Rating Logs', 'wp-postratings'); ?></h2>
+	<h1><?php esc_html_e('Manage Ratings', 'wp-postratings'); ?></h1>
+	<h2><?php esc_html_e('Rating Logs', 'wp-postratings'); ?></h2>
 	<p><?php printf(
 		/* translators: 1: Number of ratings on page 2: Max on page 3: Total rating */
-		__('Displaying %1$s to %2$s of %3$s rating log entries.', 'wp-postratings'),
+		esc_html__('Displaying %1$s to %2$s of %3$s rating log entries.', 'wp-postratings'),
 		'<strong>' . number_format_i18n( $display_on_page ) . '</strong>',
 		'<strong>' . number_format_i18n( $max_on_page ) . '</strong>',
 		'<strong>' . number_format_i18n( $total_ratings ) . '</strong>'
@@ -271,7 +271,7 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 	?></p>
 	<p><?php printf(
 		/* translators: 1: Sort by text 2: Sort order text */
-		__('Sorted by %1$s in %2$s order.', 'wp-postratings'),
+		esc_html__('Sorted by %1$s in %2$s order.', 'wp-postratings'),
 		'<strong>' . $postratings_sortby_text . '</strong>',
 		'<strong>' . $postratings_sortorder_text . '</strong>'
 		);
@@ -279,13 +279,13 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 	<table class="widefat">
 		<thead>
 			<tr>
-				<th width="2%"><?php _e('ID', 'wp-postratings'); ?></th>
-				<th width="10%"><?php _e('Username', 'wp-postratings'); ?></th>
-				<th width="10%"><?php _e('Rating', 'wp-postratings'); ?></th>
-				<th width="8%"><?php _e('Post ID', 'wp-postratings'); ?></th>
-				<th width="25%"><?php _e('Post Title', 'wp-postratings'); ?></th>
-				<th width="20%"><?php _e('Date / Time', 'wp-postratings'); ?></th>
-				<th width="25%"><?php _e('IP / Host', 'wp-postratings'); ?></th>
+				<th width="2%"><?php esc_html_e('ID', 'wp-postratings'); ?></th>
+				<th width="10%"><?php esc_html_e('Username', 'wp-postratings'); ?></th>
+				<th width="10%"><?php esc_html_e('Rating', 'wp-postratings'); ?></th>
+				<th width="8%"><?php esc_html_e('Post ID', 'wp-postratings'); ?></th>
+				<th width="25%"><?php esc_html_e('Post Title', 'wp-postratings'); ?></th>
+				<th width="20%"><?php esc_html_e('Date / Time', 'wp-postratings'); ?></th>
+				<th width="25%"><?php esc_html_e('IP / Host', 'wp-postratings'); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -353,7 +353,7 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 				$i++;
 			}
 		} else {
-			echo '<tr><td colspan="7" align="center"><strong>'.__('No Rating Logs Found', 'wp-postratings').'</strong></td></tr>';
+			echo '<tr><td colspan="7" align="center"><strong>'.esc_html__('No Rating Logs Found', 'wp-postratings').'</strong></td></tr>';
 		}
 	?>
 		</tbody>
@@ -368,7 +368,7 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 				<td align="<?php echo is_rtl() ? 'right' : 'left'; ?>" width="50%">
 					<?php
 						if($postratings_page > 1 && ((($postratings_page*$postratings_log_perpage)-($postratings_log_perpage-1)) <= $total_ratings)) {
-							echo '<strong>&laquo;</strong> <a href="'.$base_page.'&amp;ratingpage='.($postratings_page-1).$postratings_sort_url.'" title="&laquo; '.__('Previous Page', 'wp-postratings').'">'.__('Previous Page', 'wp-postratings').'</a>';
+							echo '<strong>&laquo;</strong> <a href="'.$base_page.'&amp;ratingpage='.($postratings_page-1).$postratings_sort_url.'" title="&laquo; '.esc_html__('Previous Page', 'wp-postratings').'">'.esc_html__('Previous Page', 'wp-postratings').'</a>';
 						} else {
 							echo '&nbsp;';
 						}
@@ -377,7 +377,7 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 				<td align="<?php echo is_rtl() ? 'left' : 'right'; ?>" width="50%">
 					<?php
 						if($postratings_page >= 1 && ((($postratings_page*$postratings_log_perpage)+1) <=  $total_ratings)) {
-							echo '<a href="'.$base_page.'&amp;ratingpage='.($postratings_page+1).$postratings_sort_url.'" title="'.__('Next Page', 'wp-postratings').' &raquo;">'.__('Next Page', 'wp-postratings').'</a> <strong>&raquo;</strong>';
+							echo '<a href="'.$base_page.'&amp;ratingpage='.($postratings_page+1).$postratings_sort_url.'" title="'.esc_html__('Next Page', 'wp-postratings').' &raquo;">'.esc_html__('Next Page', 'wp-postratings').'</a> <strong>&raquo;</strong>';
 						} else {
 							echo '&nbsp;';
 						}
@@ -386,28 +386,28 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 			</tr>
 			<tr class="alternate">
 				<td colspan="2" align="center">
-					<?php printf(__('Pages (%s): ', 'wp-postratings'), number_format_i18n($total_pages)); ?>
+					<?php printf(esc_html__('Pages (%s): ', 'wp-postratings'), number_format_i18n($total_pages)); ?>
 					<?php
 						if ($postratings_page >= 4) {
-							echo '<strong><a href="'.$base_page.'&amp;ratingpage=1'.$postratings_sort_url.$postratings_sort_url.'" title="'.__('Go to First Page', 'wp-postratings').'">&laquo; '.__('First', 'wp-postratings').'</a></strong> ... ';
+							echo '<strong><a href="'.$base_page.'&amp;ratingpage=1'.$postratings_sort_url.$postratings_sort_url.'" title="'.esc_html__('Go to First Page', 'wp-postratings').'">&laquo; '.esc_html__('First', 'wp-postratings').'</a></strong> ... ';
 						}
 						if($postratings_page > 1) {
-							echo ' <strong><a href="'.$base_page.'&amp;ratingpage='.($postratings_page-1).$postratings_sort_url.'" title="&laquo; '.__('Go to Page', 'wp-postratings').' '.number_format_i18n($postratings_page-1).'">&laquo;</a></strong> ';
+							echo ' <strong><a href="'.$base_page.'&amp;ratingpage='.($postratings_page-1).$postratings_sort_url.'" title="&laquo; '.esc_html__('Go to Page', 'wp-postratings').' '.number_format_i18n($postratings_page-1).'">&laquo;</a></strong> ';
 						}
 						for($i = $postratings_page - 2 ; $i  <= $postratings_page +2; $i++) {
 							if ($i >= 1 && $i <= $total_pages) {
 								if($i == $postratings_page) {
 									echo '<strong>['.number_format_i18n($i).']</strong> ';
 								} else {
-									echo '<a href="'.$base_page.'&amp;ratingpage='.($i).$postratings_sort_url.'" title="'.__('Page', 'wp-postratings').' '.number_format_i18n($i).'">'.number_format_i18n($i).'</a> ';
+									echo '<a href="'.$base_page.'&amp;ratingpage='.($i).$postratings_sort_url.'" title="'.esc_html__('Page', 'wp-postratings').' '.number_format_i18n($i).'">'.number_format_i18n($i).'</a> ';
 								}
 							}
 						}
 						if($postratings_page < $total_pages) {
-							echo ' <strong><a href="'.$base_page.'&amp;ratingpage='.($postratings_page+1).$postratings_sort_url.'" title="'.__('Go to Page', 'wp-postratings').' '.number_format_i18n($postratings_page+1).' &raquo;">&raquo;</a></strong> ';
+							echo ' <strong><a href="'.$base_page.'&amp;ratingpage='.($postratings_page+1).$postratings_sort_url.'" title="'.esc_html__('Go to Page', 'wp-postratings').' '.number_format_i18n($postratings_page+1).' &raquo;">&raquo;</a></strong> ';
 						}
 						if (($postratings_page+2) < $total_pages) {
-							echo ' ... <strong><a href="'.$base_page.'&amp;ratingpage='.($total_pages).$postratings_sort_url.'" title="'.__('Go to Last Page', 'wp-postratings').'">'.__('Last', 'wp-postratings').' &raquo;</a></strong>';
+							echo ' ... <strong><a href="'.$base_page.'&amp;ratingpage='.($total_pages).$postratings_sort_url.'" title="'.esc_html__('Go to Last Page', 'wp-postratings').'">'.esc_html__('Last', 'wp-postratings').' &raquo;</a></strong>';
 						}
 					?>
 				</td>
@@ -422,9 +422,9 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 		<input type="hidden" name="page" value="<?php echo $base_name; ?>" />
 		<table class="widefat">
 			<tr>
-				<th><?php _e('Filter Options:', 'wp-postratings'); ?></th>
+				<th><?php esc_html_e('Filter Options:', 'wp-postratings'); ?></th>
 				<td>
-					<?php _e('Post ID:', 'wp-postratings'); ?>&nbsp;<input type="text" name="id" value="<?php echo $postratings_filterid; ?>" size="7" maxlength="10" />
+					<?php esc_html_e('Post ID:', 'wp-postratings'); ?>&nbsp;<input type="text" name="id" value="<?php echo $postratings_filterid; ?>" size="7" maxlength="10" />
 					&nbsp;&nbsp;&nbsp;
 					<select name="user" size="1">
 						<option value=""></option>
@@ -435,9 +435,9 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 									$rating_username = stripslashes($filter_user->rating_username);
 									$rating_userid = intval($filter_user->rating_userid);
 									if($rating_userid > 0) {
-										$prefix = __('Registered User: ', 'wp-postratings');
+										$prefix = esc_html__('Registered User: ', 'wp-postratings');
 									} else {
-										$prefix = __('Comment Author: ', 'wp-postratings');
+										$prefix = esc_html__('Comment Author: ', 'wp-postratings');
 									}
 									if($rating_username == $postratings_filteruser) {
 										echo '<option value="'.esc_attr($rating_username).'" selected="selected">'.$prefix.' '.$rating_username.'</option>'."\n";
@@ -456,7 +456,7 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 							if($filter_ratings) {
 								foreach($filter_ratings as $filter_rating) {
 									$rating_rating = $filter_rating->rating_rating;
-									$prefix = __('Rating: ', 'wp-postratings');
+									$prefix = esc_html__('Rating: ', 'wp-postratings');
 									if($rating_rating == $postratings_filterrating) {
 										echo '<option value="'.$rating_rating.'" selected="selected">'.$prefix.' '.number_format_i18n($rating_rating).'</option>'."\n";
 									} else {
@@ -469,31 +469,31 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 				</td>
 			</tr>
 			<tr class="alternate">
-				<th><?php _e('Sort Options:', 'wp-postratings'); ?></th>
+				<th><?php esc_html_e('Sort Options:', 'wp-postratings'); ?></th>
 				<td>
 					<select name="by" size="1">
-						<option value="id"<?php if($postratings_sortby == 'rating_id') { echo ' selected="selected"'; }?>><?php _e('ID', 'wp-postratings'); ?></option>
-						<option value="username"<?php if($postratings_sortby == 'rating_username') { echo ' selected="selected"'; }?>><?php _e('Username', 'wp-postratings'); ?></option>
-						<option value="rating"<?php if($postratings_sortby == 'rating_rating') { echo ' selected="selected"'; }?>><?php _e('Rating', 'wp-postratings'); ?></option>
-						<option value="postid"<?php if($postratings_sortby == 'rating_postid') { echo ' selected="selected"'; }?>><?php _e('Post ID', 'wp-postratings'); ?></option>
-						<option value="posttitle"<?php if($postratings_sortby == 'rating_posttitle') { echo ' selected="selected"'; }?>><?php _e('Post Title', 'wp-postratings'); ?></option>
-						<option value="date"<?php if($postratings_sortby == 'rating_timestamp') { echo ' selected="selected"'; }?>><?php _e('Date', 'wp-postratings'); ?></option>
-						<option value="ip"<?php if($postratings_sortby == 'rating_ip') { echo ' selected="selected"'; }?>><?php _e('IP', 'wp-postratings'); ?></option>
-						<option value="host"<?php if($postratings_sortby == 'rating_host') { echo ' selected="selected"'; }?>><?php _e('Host', 'wp-postratings'); ?></option>
+						<option value="id"<?php if($postratings_sortby == 'rating_id') { echo ' selected="selected"'; }?>><?php esc_html_e('ID', 'wp-postratings'); ?></option>
+						<option value="username"<?php if($postratings_sortby == 'rating_username') { echo ' selected="selected"'; }?>><?php esc_html_e('Username', 'wp-postratings'); ?></option>
+						<option value="rating"<?php if($postratings_sortby == 'rating_rating') { echo ' selected="selected"'; }?>><?php esc_html_e('Rating', 'wp-postratings'); ?></option>
+						<option value="postid"<?php if($postratings_sortby == 'rating_postid') { echo ' selected="selected"'; }?>><?php esc_html_e('Post ID', 'wp-postratings'); ?></option>
+						<option value="posttitle"<?php if($postratings_sortby == 'rating_posttitle') { echo ' selected="selected"'; }?>><?php esc_html_e('Post Title', 'wp-postratings'); ?></option>
+						<option value="date"<?php if($postratings_sortby == 'rating_timestamp') { echo ' selected="selected"'; }?>><?php esc_html_e('Date', 'wp-postratings'); ?></option>
+						<option value="ip"<?php if($postratings_sortby == 'rating_ip') { echo ' selected="selected"'; }?>><?php esc_html_e('IP', 'wp-postratings'); ?></option>
+						<option value="host"<?php if($postratings_sortby == 'rating_host') { echo ' selected="selected"'; }?>><?php esc_html_e('Host', 'wp-postratings'); ?></option>
 					</select>
 					&nbsp;&nbsp;&nbsp;
 					<select name="order" size="1">
-						<option value="asc"<?php if($postratings_sortorder == 'asc') { echo ' selected="selected"'; }?>><?php _e('Ascending', 'wp-postratings'); ?></option>
-						<option value="desc"<?php if($postratings_sortorder == 'desc') { echo ' selected="selected"'; } ?>><?php _e('Descending', 'wp-postratings'); ?></option>
+						<option value="asc"<?php if($postratings_sortorder == 'asc') { echo ' selected="selected"'; }?>><?php esc_html_e('Ascending', 'wp-postratings'); ?></option>
+						<option value="desc"<?php if($postratings_sortorder == 'desc') { echo ' selected="selected"'; } ?>><?php esc_html_e('Descending', 'wp-postratings'); ?></option>
 					</select>
 					&nbsp;&nbsp;&nbsp;
 					<select name="perpage" size="1">
 					<?php
 						for($i=10; $i <= 100; $i+=10) {
 							if($postratings_log_perpage == $i) {
-								echo "<option value=\"$i\" selected=\"selected\">".__('Per Page', 'wp-postratings').": ".number_format_i18n($i)."</option>\n";
+								echo "<option value=\"$i\" selected=\"selected\">".esc_html__('Per Page', 'wp-postratings').": ".number_format_i18n($i)."</option>\n";
 							} else {
-								echo "<option value=\"$i\">".__('Per Page', 'wp-postratings').": ".number_format_i18n($i)."</option>\n";
+								echo "<option value=\"$i\">".esc_html__('Per Page', 'wp-postratings').": ".number_format_i18n($i)."</option>\n";
 							}
 						}
 					?>
@@ -501,7 +501,7 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 				</td>
 			</tr>
 			<tr>
-				<td colspan="2" align="center"><input type="submit" value="<?php _e('Go', 'wp-postratings'); ?>" class="button" /></td>
+				<td colspan="2" align="center"><input type="submit" value="<?php esc_html_e('Go', 'wp-postratings'); ?>" class="button" /></td>
 			</tr>
 		</table>
 	</form>
@@ -510,19 +510,19 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 
 <!-- Post Ratings Stats -->
 <div class="wrap">
-	<h2><?php _e('Rating Stats', 'wp-postratings'); ?></h2>
+	<h2><?php esc_html_e('Rating Stats', 'wp-postratings'); ?></h2>
 	<br style="clear" />
 	<table class="widefat">
 		<tr>
-			<th><?php _e('Total Users Voted:', 'wp-postratings'); ?></th>
+			<th><?php esc_html_e('Total Users Voted:', 'wp-postratings'); ?></th>
 			<td><?php echo number_format_i18n($total_users); ?></td>
 		</tr>
 		<tr class="alternate">
-			<th><?php _e('Total Score:', 'wp-postratings'); ?></th>
+			<th><?php esc_html_e('Total Score:', 'wp-postratings'); ?></th>
 			<td><?php echo number_format_i18n($total_score); ?></td>
 		</tr>
 		<tr>
-			<th><?php _e('Total Average:', 'wp-postratings'); ?></th>
+			<th><?php esc_html_e('Total Average:', 'wp-postratings'); ?></th>
 			<td><?php echo number_format_i18n($total_average, 2); ?></td>
 		</tr>
 	</table>
@@ -531,44 +531,44 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 
 <!-- Delete Post Ratings Logs -->
 <div class="wrap">
-	<h2><?php _e('Delete Ratings Data/Logs', 'wp-postratings'); ?></h2>
+	<h2><?php esc_html_e('Delete Ratings Data/Logs', 'wp-postratings'); ?></h2>
 	<br style="clear" />
 	<div align="center">
 		<form method="post" action="<?php echo esc_url( $base_page ); ?>">
 		<?php wp_nonce_field('wp-postratings_logs'); ?>
 		<table class="widefat">
 			<tr>
-				<td valign="top"><b><?php _e('Delete Type: ', 'wp-postratings'); ?></b></td>
+				<td valign="top"><b><?php esc_html_e('Delete Type: ', 'wp-postratings'); ?></b></td>
 				<td valign="top">
 					<select size="1" name="delete_datalog">
-						<option value="1"><?php _e('Logs Only', 'wp-postratings'); ?></option>
-						<option value="2"><?php _e('Data Only', 'wp-postratings'); ?></option>
-						<option value="3"><?php _e('Logs And Data', 'wp-postratings'); ?></option>
+						<option value="1"><?php esc_html_e('Logs Only', 'wp-postratings'); ?></option>
+						<option value="2"><?php esc_html_e('Data Only', 'wp-postratings'); ?></option>
+						<option value="3"><?php esc_html_e('Logs And Data', 'wp-postratings'); ?></option>
 					</select>
 				</td>
 			</tr>
 			<tr>
-				<td valign="top"><b><?php _e('Post ID(s):', 'wp-postratings'); ?></b></td>
+				<td valign="top"><b><?php esc_html_e('Post ID(s):', 'wp-postratings'); ?></b></td>
 				<td valign="top">
 					<input type="text" name="delete_postid" size="20" dir="ltr" />
-					<p><?php _e('Seperate each Post ID with a comma.', 'wp-postratings'); ?></p>
-					<p><?php _e('To delete ratings data/logs from Post ID 2, 3 and 4. Just type in: <b>2,3,4</b>', 'wp-postratings'); ?></p>
-					<p><?php _e('To delete ratings data/logs for all posts. Just type in: <b>all</b>', 'wp-postratings'); ?></p>
+					<p><?php esc_html_e('Seperate each Post ID with a comma.', 'wp-postratings'); ?></p>
+					<p><?php esc_html_e('To delete ratings data/logs from Post ID 2, 3 and 4. Just type in: <b>2,3,4</b>', 'wp-postratings'); ?></p>
+					<p><?php esc_html_e('To delete ratings data/logs for all posts. Just type in: <b>all</b>', 'wp-postratings'); ?></p>
 				</td>
 			</tr>
 			<tr>
 				<td colspan="2" align="center">
-					<input type="submit" name="do" value="<?php _e('Delete Data/Logs', 'wp-postratings'); ?>" class="button" onclick="return confirm('<?php _e('You Are About To Delete Post Ratings Data/Logs.\nThis Action Is Not Reversible.\n\n Choose \\\'Cancel\\\' to stop, \\\'OK\\\' to delete.', 'wp-postratings'); ?>')" />
+					<input type="submit" name="do" value="<?php esc_html_e('Delete Data/Logs', 'wp-postratings'); ?>" class="button" onclick="return confirm('<?php esc_html_e('You Are About To Delete Post Ratings Data/Logs.\nThis Action Is Not Reversible.\n\n Choose \\\'Cancel\\\' to stop, \\\'OK\\\' to delete.', 'wp-postratings'); ?>')" />
 				</td>
 			</tr>
 		</table>
 		</form>
 	</div>
-	<h2><?php _e('Note:', 'wp-postratings'); ?></h2>
+	<h2><?php esc_html_e('Note:', 'wp-postratings'); ?></h2>
 	<ul>
-		<li><?php _e('\'Logs Only\' means the logs generated when a user rates a post.', 'wp-postratings'); ?></li>
-		<li><?php _e('\'Data Only\' means the rating data for the post.', 'wp-postratings'); ?></li>
-		<li><?php _e('\'Logs And Data\' means both the logs generated and the rating data for the post.', 'wp-postratings'); ?></li>
-		<li><?php _e('If your logging method is by IP and Cookie or by Cookie, users may still be unable to rate if they have voted before as the cookie is still stored in their computer.', 'wp-postratings'); ?></li>
+		<li><?php esc_html_e('\'Logs Only\' means the logs generated when a user rates a post.', 'wp-postratings'); ?></li>
+		<li><?php esc_html_e('\'Data Only\' means the rating data for the post.', 'wp-postratings'); ?></li>
+		<li><?php esc_html_e('\'Logs And Data\' means both the logs generated and the rating data for the post.', 'wp-postratings'); ?></li>
+		<li><?php esc_html_e('If your logging method is by IP and Cookie or by Cookie, users may still be unable to rate if they have voted before as the cookie is still stored in their computer.', 'wp-postratings'); ?></li>
 	</ul>
 </div>

--- a/postratings-manager.php
+++ b/postratings-manager.php
@@ -299,13 +299,13 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 					$style = '';
 				}
 				$postratings_id = intval($postratings_log->rating_id);
-				$postratings_username = stripslashes($postratings_log->rating_username);
+				$postratings_username = esc_html( stripslashes($postratings_log->rating_username) );
 				$postratings_rating = intval($postratings_log->rating_rating);
 				$postratings_postid = intval($postratings_log->rating_postid);
-				$postratings_posttitle = stripslashes($postratings_log->rating_posttitle);
-				$postratings_date = mysql2date(sprintf(__('%s @ %s', 'wp-postratings'), get_option('date_format'), get_option('time_format')), gmdate('Y-m-d H:i:s', $postratings_log->rating_timestamp));
-				$postratings_ip = $postratings_log->rating_ip;
-				$postratings_host = $postratings_log->rating_host;
+				$postratings_posttitle = esc_html( stripslashes($postratings_log->rating_posttitle) );
+				$postratings_date = esc_html(mysql2date(sprintf(__('%s @ %s', 'wp-postratings'), get_option('date_format'), get_option('time_format')), gmdate('Y-m-d H:i:s', $postratings_log->rating_timestamp)));
+				$postratings_ip = esc_html( $postratings_log->rating_ip );
+				$postratings_host = esc_html( $postratings_log->rating_host );
 				echo "<tr $style>\n";
 				echo '<td>'.$postratings_id.'</td>'."\n";
 				echo "<td>$postratings_username</td>\n";
@@ -432,7 +432,7 @@ $postratings_logs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->r
 							$filter_users = $wpdb->get_results( $wpdb->prepare( "SELECT DISTINCT rating_username, rating_userid FROM {$wpdb->ratings} WHERE rating_username != %s ORDER BY rating_userid ASC, rating_username ASC", __(' Guest', 'wp-postratings' ) ) );
 							if($filter_users) {
 								foreach($filter_users as $filter_user) {
-									$rating_username = stripslashes($filter_user->rating_username);
+									$rating_username = esc_html(stripslashes($filter_user->rating_username));
 									$rating_userid = intval($filter_user->rating_userid);
 									if($rating_userid > 0) {
 										$prefix = esc_html__('Registered User: ', 'wp-postratings');

--- a/postratings-manager.php
+++ b/postratings-manager.php
@@ -223,9 +223,9 @@ if ( ! empty( $postratings_filterrating ) )
 	$postratings_where .= $wpdb->prepare( " AND rating_rating = %d", $postratings_filterrating );
 
 // Get Post Ratings Logs Data
-$total_ratings = $wpdb->get_var("SELECT COUNT(rating_id) FROM $wpdb->ratings WHERE 1=1 $postratings_where");
-$total_users = $wpdb->get_var("SELECT SUM(meta_value) FROM $wpdb->postmeta WHERE meta_key = 'ratings_users'");
-$total_score = $wpdb->get_var("SELECT SUM((meta_value+0.00)) FROM $wpdb->postmeta WHERE meta_key = 'ratings_score'");
+$total_ratings = intval($wpdb->get_var("SELECT COUNT(rating_id) FROM $wpdb->ratings WHERE 1=1 $postratings_where"));
+$total_users = intval($wpdb->get_var("SELECT SUM(meta_value) FROM $wpdb->postmeta WHERE meta_key = 'ratings_users'"));
+$total_score = intval($wpdb->get_var("SELECT SUM((meta_value+0.00)) FROM $wpdb->postmeta WHERE meta_key = 'ratings_score'"));
 $ratings_custom = intval(get_option('postratings_customrating'));
 if($total_users == 0) {
 	$total_average = 0;

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -34,20 +34,20 @@ $base_page = 'admin.php?page='.$base_name;
 if ( isset( $_POST['Submit'] ) ) {
     check_admin_referer('wp-postratings_options');
     $postratings_customrating = intval($_POST['postratings_customrating']);
-    $postratings_template_vote = trim($_POST['postratings_template_vote']);
-    $postratings_template_text = trim($_POST['postratings_template_text']);
-    $postratings_template_permission = trim($_POST['postratings_template_permission']);
-    $postratings_template_none = trim($_POST['postratings_template_none']);
-    $postratings_template_highestrated = trim($_POST['postratings_template_highestrated']);
-    $postratings_template_mostrated = trim($_POST['postratings_template_mostrated']);
-    $postratings_image = strip_tags(trim($_POST['postratings_image']));
+    $postratings_template_vote = wp_kses_post(trim($_POST['postratings_template_vote']));
+    $postratings_template_text = wp_kses_post(trim($_POST['postratings_template_text']));
+    $postratings_template_permission = wp_kses_post(trim($_POST['postratings_template_permission']));
+    $postratings_template_none = wp_kses_post(trim($_POST['postratings_template_none']));
+    $postratings_template_highestrated = wp_kses_post(trim($_POST['postratings_template_highestrated']));
+    $postratings_template_mostrated = wp_kses_post(trim($_POST['postratings_template_mostrated']));
+    $postratings_image = sanitize_file_name(strip_tags(trim($_POST['postratings_image'])));
     $postratings_max = intval($_POST['postratings_max']);
     $postratings_richsnippet = intval($_POST['postratings_richsnippet']);
     $postratings_ratingstext_array = $_POST['postratings_ratingstext'];
     $postratings_ratingstext = array();
     if( ! empty( $postratings_ratingstext_array ) && is_array( $postratings_ratingstext_array ) ) {
         foreach( $postratings_ratingstext_array as $ratingstext ) {
-            $postratings_ratingstext[] = trim( $ratingstext );
+            $postratings_ratingstext[] = wp_kses_post(trim( $ratingstext ));
         }
     }
     $postratings_ratingsvalue_array = $_POST['postratings_ratingsvalue'];

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Check whether the user can manage ratings
  */
 if ( ! current_user_can( 'manage_ratings' ) ) {
-    wp_die( __( 'Access Denied', 'wp-postratings' ) );
+    wp_die( esc_html__( 'Access Denied', 'wp-postratings' ) );
 }
 
 
@@ -124,22 +124,22 @@ $postratings_image = get_option('postratings_image');
         var default_template;
         switch(template) {
             case "vote":
-                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
                 break;
             case "text":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong><?php _e('rated', 'wp-postratings'); ?></strong></em>)";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
                 break;
             case "permission":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong><?php _e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php _e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
                 break;
             case "none":
-                default_template = "%RATINGS_IMAGES_VOTE% (<?php _e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+                default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
                 break;
             case "highestrated":
-                default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> %RATINGS_USERS% <?php _e('votes', 'wp-postratings'); ?>)</li>";
+                default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?>)</li>";
                 break;
             case "mostrated":
-                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php _e('votes', 'wp-postratings'); ?></li>";
+                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
                 break;
         }
         if(print) {
@@ -152,22 +152,22 @@ $postratings_image = get_option('postratings_image');
         var default_template;
         switch(template) {
             case "vote":
-                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <?php _e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
+                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
                 break;
             case "text":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <?php _e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php _e(',', 'wp-postratings'); ?> <strong><?php _e('rated', 'wp-postratings'); ?></strong></em>)";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
                 break;
             case "permission":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <?php _e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php _e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
                 break;
             case "none":
-                default_template = "%RATINGS_IMAGES_VOTE% (<?php _e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+                default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
                 break;
             case "highestrated":
-                default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> %RATINGS_IMAGES% (%RATINGS_AVERAGE% <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)</li>";
+                default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> %RATINGS_IMAGES% (%RATINGS_AVERAGE% <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)</li>";
                 break;
             case "mostrated":
-                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php _e('votes', 'wp-postratings'); ?></li>";
+                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
                 break;
         }
         if(print) {

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -348,14 +348,14 @@ $postratings_image = get_option('postratings_image');
                             }
                             echo '</td>'."\n";
                             echo '<td>'."\n";
-                            echo '<input type="text" id="postratings_ratingstext_'.$i.'" name="postratings_ratingstext[]" value="'.stripslashes($postratings_ratingstext[$i-1]).'" size="20" maxlength="50" />'."\n";
+                            echo '<input type="text" id="postratings_ratingstext_'.$i.'" name="postratings_ratingstext[]" value="'.esc_attr(stripslashes($postratings_ratingstext[$i-1])).'" size="20" maxlength="50" />'."\n";
                             echo '</td>'."\n";
                             echo '<td>'."\n";
                             echo '<input type="text" id="postratings_ratingsvalue_'.$i.'" name="postratings_ratingsvalue[]" value="';
                             if($postratings_ratingsvalue[$i-1] > 0 && $postratings_customrating) {
                                 echo '+';
                             }
-                            echo $postratings_ratingsvalue[$i-1].'" size="3" maxlength="5" />'."\n";
+                            echo intval($postratings_ratingsvalue[$i-1]).'" size="3" maxlength="5" />'."\n";
                             echo '</td>'."\n";
                             echo '</tr>'."\n";
                         }

--- a/postratings-templates.php
+++ b/postratings-templates.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Check whether the user can manage ratings
  */
 if ( ! current_user_can( 'manage_ratings' ) ) {
-	wp_die( __( 'Access Denied', 'wp-postratings' ) );
+	wp_die( esc_html__( 'Access Denied', 'wp-postratings' ) );
 }
 
 
@@ -47,22 +47,22 @@ if ( isset( $_POST['Submit'] ) ) {
 	$update_ratings_queries[] = update_option('postratings_template_none', $postratings_template_none);
 	$update_ratings_queries[] = update_option('postratings_template_highestrated', $postratings_template_highestrated);
 	$update_ratings_queries[] = update_option('postratings_template_mostrated', $postratings_template_mostrated);
-	$update_ratings_text[] = __('Ratings Template Vote', 'wp-postratings');
-	$update_ratings_text[] = __('Ratings Template Voted', 'wp-postratings');
-	$update_ratings_text[] = __('Ratings Template No Permission', 'wp-postratings');
+	$update_ratings_text[] = esc_html__('Ratings Template Vote', 'wp-postratings');
+	$update_ratings_text[] = esc_html__('Ratings Template Voted', 'wp-postratings');
+	$update_ratings_text[] = esc_html__('Ratings Template No Permission', 'wp-postratings');
 	$update_ratings_text[] = __('Ratings Template For No Ratings', 'wp-postratings');
-	$update_ratings_text[] = __('Ratings Template For Highest Rated', 'wp-postratings');
-	$update_ratings_text[] = __('Ratings Template For Most Rated', 'wp-postratings');
+	$update_ratings_text[] = esc_html__('Ratings Template For Highest Rated', 'wp-postratings');
+	$update_ratings_text[] = esc_html__('Ratings Template For Most Rated', 'wp-postratings');
 	$i = 0;
 	$text = '';
 	foreach($update_ratings_queries as $update_ratings_query) {
 		if($update_ratings_query) {
-			$text .= '<p style="color: green;">'.$update_ratings_text[$i].' '.__('Updated', 'wp-postratings').'</p>';
+			$text .= '<p style="color: green;">'.$update_ratings_text[$i].' '.esc_html__('Updated', 'wp-postratings').'</p>';
 		}
 		$i++;
 	}
 	if(empty($text)) {
-		$text = '<p style="color: red;">'.__('No Ratings Templates Updated', 'wp-postratings').'</p>';
+		$text = '<p style="color: red;">'.esc_html__('No Ratings Templates Updated', 'wp-postratings').'</p>';
 	}
 }
 ?>
@@ -72,22 +72,22 @@ if ( isset( $_POST['Submit'] ) ) {
 		var default_template;
 		switch(template) {
 			case "vote":
-				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
 				break;
 			case "text":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong><?php _e('rated', 'wp-postratings'); ?></strong></em>)";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
 				break;
 			case "permission":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <strong><?php _e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php _e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
 				break;
 			case "none":
-				default_template = "%RATINGS_IMAGES_VOTE% (<?php _e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+				default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
 				break;
 			case "highestrated":
-				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php _e('rating', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> %RATINGS_USERS% <?php _e('votes', 'wp-postratings'); ?>)</li>";
+				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?>)</li>";
 				break;
 			case "mostrated":
-				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php _e('votes', 'wp-postratings'); ?></li>";
+				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
 				break;
 		}
 		if(print) {
@@ -100,22 +100,22 @@ if ( isset( $_POST['Submit'] ) ) {
 		var default_template;
 		switch(template) {
 			case "vote":
-				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <?php _e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
+				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
 				break;
 			case "text":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <?php _e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php _e(',', 'wp-postratings'); ?> <strong><?php _e('rated', 'wp-postratings'); ?></strong></em>)";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
 				break;
 			case "permission":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php _e('votes', 'wp-postratings'); ?><?php _e(',', 'wp-postratings'); ?> <?php _e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php _e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
 				break;
 			case "none":
-				default_template = "%RATINGS_IMAGES_VOTE% (<?php _e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+				default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
 				break;
 			case "highestrated":
-				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> %RATINGS_IMAGES% (%RATINGS_AVERAGE% <?php _e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)</li>";
+				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> %RATINGS_IMAGES% (%RATINGS_AVERAGE% <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)</li>";
 				break;
 			case "mostrated":
-				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php _e('votes', 'wp-postratings'); ?></li>";
+				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
 				break;
 		}
 		if(print) {
@@ -128,34 +128,34 @@ if ( isset( $_POST['Submit'] ) ) {
 </script>
 <?php if(!empty($text)) { echo '<!-- Last Action --><div id="message" class="updated fade"><p>'.$text.'</p></div>'; } ?>
 <div class="wrap">
-	<h1><?php _e('Post Ratings Templates', 'wp-postratings'); ?></h1>
+	<h1><?php esc_html_e('Post Ratings Templates', 'wp-postratings'); ?></h1>
 	<form method="post" action="<?php echo admin_url('admin.php?page='.plugin_basename(__FILE__)); ?>">
 		<?php wp_nonce_field('wp-postratings_templates'); ?>
-		<h2><?php _e('Template Variables', 'wp-postratings'); ?></h2>
+		<h2><?php esc_html_e('Template Variables', 'wp-postratings'); ?></h2>
 		<table class="form-table">
 			<tr>
-				<td><strong>%RATINGS_IMAGES%</strong> - <?php _e('Display the ratings images', 'wp-postratings'); ?></td>
-				<td><strong>%RATINGS_IMAGES_VOTE%</strong> - <?php _e('Display the ratings voting image', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_IMAGES%</strong> - <?php esc_html_e('Display the ratings images', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_IMAGES_VOTE%</strong> - <?php esc_html_e('Display the ratings voting image', 'wp-postratings'); ?></td>
 			</tr>
 			<tr>
-				<td><strong>%RATINGS_AVERAGE%</strong> - <?php _e('Display the average ratings', 'wp-postratings'); ?></td>
-				<td><strong>%RATINGS_USERS%</strong> - <?php _e('Display the total number of users rated for the post', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_AVERAGE%</strong> - <?php esc_html_e('Display the average ratings', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_USERS%</strong> - <?php esc_html_e('Display the total number of users rated for the post', 'wp-postratings'); ?></td>
 			</tr>
 			<tr>
-				<td><strong>%RATINGS_MAX%</strong> - <?php _e('Display the max number of ratings', 'wp-postratings'); ?></td>
-				<td><strong>%RATINGS_PERCENTAGE%</strong> - <?php _e('Display the ratings percentage', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_MAX%</strong> - <?php esc_html_e('Display the max number of ratings', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_PERCENTAGE%</strong> - <?php esc_html_e('Display the ratings percentage', 'wp-postratings'); ?></td>
 			</tr>
 			<tr>
-				<td><strong>%RATINGS_SCORE%</strong> - <?php _e('Display the total score of the ratings', 'wp-postratings'); ?></td>
-				<td><strong>%RATINGS_TEXT%</strong> - <?php _e('Display the individual rating text. Eg: 1 Star, 2 Stars, etc', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_SCORE%</strong> - <?php esc_html_e('Display the total score of the ratings', 'wp-postratings'); ?></td>
+				<td><strong>%RATINGS_TEXT%</strong> - <?php esc_html_e('Display the individual rating text. Eg: 1 Star, 2 Stars, etc', 'wp-postratings'); ?></td>
 			</tr>
 		</table>
-		<h2><?php _e('Ratings Templates', 'wp-postratings'); ?></h2>
+		<h2><?php esc_html_e('Ratings Templates', 'wp-postratings'); ?></h2>
 		<table class="form-table">
 			 <tr>
 				<td width="30%">
-					<strong><?php _e('Ratings Vote Text:', 'wp-postratings'); ?></strong><br /><br />
-					<?php _e('Allowed Variables:', 'wp-postratings'); ?>
+					<strong><?php esc_html_e('Ratings Vote Text:', 'wp-postratings'); ?></strong><br /><br />
+					<?php esc_html_e('Allowed Variables:', 'wp-postratings'); ?>
 					<p style="margin: 2px 0">- %RATINGS_IMAGES_VOTE%</p>
 					<p style="margin: 2px 0">- %RATINGS_MAX%</p>
 					<p style="margin: 2px 0">- %RATINGS_SCORE%</p>
@@ -163,46 +163,46 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %RATINGS_PERCENTAGE%</p>
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('vote', true);" class="button" />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('vote', true);" class="button" />
 					<br />
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('vote', true);" class="button" />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('vote', true);" class="button" />
 				</td>
 				<td><textarea cols="80" rows="15" id="postratings_template_vote" name="postratings_template_vote"><?php echo esc_attr(stripslashes(get_option('postratings_template_vote'))); ?></textarea></td>
 			</tr>
 			<tr>
 				<td width="30%">
-					<strong><?php _e('Ratings Voted Text:', 'wp-postratings'); ?></strong><br /><br />
-					<?php _e('Allowed Variables:', 'wp-postratings'); ?>
+					<strong><?php esc_html_e('Ratings Voted Text:', 'wp-postratings'); ?></strong><br /><br />
+					<?php esc_html_e('Allowed Variables:', 'wp-postratings'); ?>
 					<p style="margin: 2px 0">- %RATINGS_IMAGES%</p>
 					<p style="margin: 2px 0">- %RATINGS_MAX%</p>
 					<p style="margin: 2px 0">- %RATINGS_SCORE%</p>
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %RATINGS_PERCENTAGE%</p>
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('text', true);" class="button" /><br />
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('text', true);" class="button" />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('text', true);" class="button" /><br />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('text', true);" class="button" />
 				</td>
 				<td><textarea cols="80" rows="15" id="postratings_template_text" name="postratings_template_text"><?php echo esc_attr(stripslashes(get_option('postratings_template_text'))); ?></textarea></td>
 			</tr>
 			<tr>
 				<td width="30%">
-					<strong><?php _e('Ratings No Permission Text:', 'wp-postratings'); ?></strong><br /><br />
-					<?php _e('Allowed Variables:', 'wp-postratings'); ?>
+					<strong><?php esc_html_e('Ratings No Permission Text:', 'wp-postratings'); ?></strong><br /><br />
+					<?php esc_html_e('Allowed Variables:', 'wp-postratings'); ?>
 					<p style="margin: 2px 0">- %RATINGS_IMAGES%</p>
 					<p style="margin: 2px 0">- %RATINGS_MAX%</p>
 					<p style="margin: 2px 0">- %RATINGS_SCORE%</p>
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %RATINGS_PERCENTAGE%</p>
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('permission', true);" class="button" /><br />
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('permission', true);" class="button" />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('permission', true);" class="button" /><br />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('permission', true);" class="button" />
 				</td>
 				<td><textarea cols="80" rows="15" id="postratings_template_permission" name="postratings_template_permission"><?php echo esc_attr(stripslashes(get_option('postratings_template_permission'))); ?></textarea></td>
 			</tr>
 			<tr>
 				<td width="30%">
-					<strong><?php _e('Ratings None:', 'wp-postratings'); ?></strong><br /><br />
-					<?php _e('Allowed Variables:', 'wp-postratings'); ?><br />
+					<strong><?php esc_html_e('Ratings None:', 'wp-postratings'); ?></strong><br /><br />
+					<?php esc_html_e('Allowed Variables:', 'wp-postratings'); ?><br />
 					<p style="margin: 2px 0">- %RATINGS_IMAGES_VOTE%</p>
 					<p style="margin: 2px 0">- %RATINGS_MAX%</p>
 					<p style="margin: 2px 0">- %RATINGS_SCORE%</p>
@@ -210,15 +210,15 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %RATINGS_PERCENTAGE%</p>
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('none', true);" class="button" /><br />
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('none', true);" class="button" />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('none', true);" class="button" /><br />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('none', true);" class="button" />
 				</td>
 				<td><textarea cols="80" rows="15" id="postratings_template_none" name="postratings_template_none"><?php echo esc_attr(stripslashes(get_option('postratings_template_none'))); ?></textarea></td>
 			</tr>
 			<tr>
 				<td width="30%">
-					<strong><?php _e('Highest Rated:', 'wp-postratings'); ?></strong><br /><br />
-					<?php _e('Allowed Variables:', 'wp-postratings'); ?><br />
+					<strong><?php esc_html_e('Highest Rated:', 'wp-postratings'); ?></strong><br /><br />
+					<?php esc_html_e('Allowed Variables:', 'wp-postratings'); ?><br />
 					<p style="margin: 2px 0">- %RATINGS_IMAGES%</p>
 					<p style="margin: 2px 0">- %RATINGS_MAX%</p>
 					<p style="margin: 2px 0">- %RATINGS_SCORE%</p>
@@ -231,15 +231,15 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %POST_CONTENT%</p>
 					<p style="margin: 2px 0">- %POST_URL%</p>
 					<p style="margin: 2px 0">- %POST_THUMBNAIL%</p>
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('highestrated', true);" class="button" /><br />
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('highestrated', true);" class="button" />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('highestrated', true);" class="button" /><br />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('highestrated', true);" class="button" />
 				</td>
 				<td><textarea cols="80" rows="15" id="postratings_template_highestrated" name="postratings_template_highestrated"><?php echo esc_attr(stripslashes(get_option('postratings_template_highestrated'))); ?></textarea></td>
 			</tr>
 			<tr>
 				<td width="30%">
-					<strong><?php _e('Most Rated:', 'wp-postratings'); ?></strong><br /><br />
-					<?php _e('Allowed Variables:', 'wp-postratings'); ?><br />
+					<strong><?php esc_html_e('Most Rated:', 'wp-postratings'); ?></strong><br /><br />
+					<?php esc_html_e('Allowed Variables:', 'wp-postratings'); ?><br />
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %POST_ID%</p>
@@ -248,14 +248,14 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %POST_CONTENT%</p>
 					<p style="margin: 2px 0">- %POST_URL%</p>
 					<p style="margin: 2px 0">- %POST_THUMBNAIL%</p>
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('mostrated', true);" class="button" /><br />
-					<input type="button" name="RestoreDefault" value="<?php _e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('mostrated', true);" class="button" />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('mostrated', true);" class="button" /><br />
+					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('mostrated', true);" class="button" />
 				</td>
 				<td><textarea cols="80" rows="15" id="postratings_template_mostrated" name="postratings_template_mostrated"><?php echo esc_attr(stripslashes(get_option('postratings_template_mostrated'))); ?></textarea></td>
 			</tr>
 		</table>
 		<p class="submit">
-			<input type="submit" name="Submit" class="button-primary" value="<?php _e('Save Changes', 'wp-postratings'); ?>" />
+			<input type="submit" name="Submit" class="button-primary" value="<?php esc_html_e('Save Changes', 'wp-postratings'); ?>" />
 		</p>
 	</form>
 </div>

--- a/postratings-templates.php
+++ b/postratings-templates.php
@@ -33,12 +33,12 @@ $base_page = 'admin.php?page='.$base_name;
 ### If Form Is Submitted
 if ( isset( $_POST['Submit'] ) ) {
 	check_admin_referer('wp-postratings_templates');
-	$postratings_template_vote = trim($_POST['postratings_template_vote']);
-	$postratings_template_text = trim($_POST['postratings_template_text']);
-	$postratings_template_permission = trim($_POST['postratings_template_permission']);
-	$postratings_template_none = trim($_POST['postratings_template_none']);
-	$postratings_template_highestrated = trim($_POST['postratings_template_highestrated']);
-	$postratings_template_mostrated = trim($_POST['postratings_template_mostrated']);
+	$postratings_template_vote = wp_kses_post(trim($_POST['postratings_template_vote']));
+	$postratings_template_text = wp_kses_post(trim($_POST['postratings_template_text']));
+	$postratings_template_permission = wp_kses_post(trim($_POST['postratings_template_permission']));
+	$postratings_template_none = wp_kses_post(trim($_POST['postratings_template_none']));
+	$postratings_template_highestrated = wp_kses_post(trim($_POST['postratings_template_highestrated']));
+	$postratings_template_mostrated = wp_kses_post(trim($_POST['postratings_template_mostrated']));
 	$update_ratings_queries = array();
 	$update_ratings_text = array();
 	$update_ratings_queries[] = update_option('postratings_template_vote', $postratings_template_vote);

--- a/postratings-templates.php
+++ b/postratings-templates.php
@@ -50,7 +50,7 @@ if ( isset( $_POST['Submit'] ) ) {
 	$update_ratings_text[] = esc_html__('Ratings Template Vote', 'wp-postratings');
 	$update_ratings_text[] = esc_html__('Ratings Template Voted', 'wp-postratings');
 	$update_ratings_text[] = esc_html__('Ratings Template No Permission', 'wp-postratings');
-	$update_ratings_text[] = __('Ratings Template For No Ratings', 'wp-postratings');
+	$update_ratings_text[] = esc_html__('Ratings Template For No Ratings', 'wp-postratings');
 	$update_ratings_text[] = esc_html__('Ratings Template For Highest Rated', 'wp-postratings');
 	$update_ratings_text[] = esc_html__('Ratings Template For Most Rated', 'wp-postratings');
 	$i = 0;

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1043,9 +1043,9 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
     $ratings_options = get_option('postratings_options');
 
     if(is_object($post_data)) {
-        $post_id = $post_data->ID;
+        $post_id = inval($post_data->ID);
     } else {
-        $post_id = $post_data;
+        $post_id = intval($post_data);
     }
 
     // Most likely from coming from Widget

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1048,7 +1048,7 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
     $ratings_options = get_option('postratings_options');
 
     if(is_object($post_data)) {
-        $post_id = inval($post_data->ID);
+        $post_id = intval($post_data->ID);
     } else {
         $post_id = intval($post_data);
     }

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -92,6 +92,8 @@ function the_ratings($start_tag = 'div', $custom_id = 0, $display = true) {
         }
     }
 
+    $ratings_id = (int) $ratings_id;
+
     // Loading Style
     $postratings_ajax_style = get_option('postratings_ajax_style');
     if(intval($postratings_ajax_style['loading']) == 1) {

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -623,9 +623,9 @@ function manage_ratings()
         } else {
             for($i = 0; $i < $postratings_max; $i++) {
                 if($i > 0) {
-                    $postratings_ratingstext[$i] = sprintf(__('%s Stars', 'wp-postratings'), number_format_i18n($i+1));
+                    $postratings_ratingstext[$i] = sprintf(esc_html__('%s Stars', 'wp-postratings'), number_format_i18n($i+1));
                 } else {
-                    $postratings_ratingstext[$i] = sprintf(__('%s Star', 'wp-postratings'), number_format_i18n($i+1));
+                    $postratings_ratingstext[$i] = sprintf(esc_html__('%s Star', 'wp-postratings'), number_format_i18n($i+1));
                 }
                 $postratings_ratingsvalue[$i] = $i+1;
             }
@@ -816,24 +816,24 @@ function postratings_page_admin_most_stats($content) {
     $stats_display = get_option('stats_display');
     $stats_mostlimit = intval(get_option('stats_mostlimit'));
     if($stats_display['rated_highest_post'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_post" value="rated_highest_post" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_highest_post">'.sprintf(_n('%s Highest Rated Post', '%s Highest Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_post" value="rated_highest_post" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_highest_post">'.esc_html(sprintf(_n('%s Highest Rated Post', '%s Highest Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_post" value="rated_highest_post" />&nbsp;&nbsp;<label for="wpstats_rated_highest_post">'.sprintf(_n('%s Highest Rated Post', '%s Highest Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_post" value="rated_highest_post" />&nbsp;&nbsp;<label for="wpstats_rated_highest_post">'.esc_html(sprintf(_n('%s Highest Rated Post', '%s Highest Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     }
     if($stats_display['rated_highest_page'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_page" value="rated_highest_page" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_highest_page">'.sprintf(_n('%s Highest Rated Page', '%s Highest Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_page" value="rated_highest_page" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_highest_page">'.esc_html(sprintf(_n('%s Highest Rated Page', '%s Highest Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_page" value="rated_highest_page" />&nbsp;&nbsp;<label for="wpstats_rated_highest_page">'.sprintf(_n('%s Highest Rated Page', '%s Highest Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_page" value="rated_highest_page" />&nbsp;&nbsp;<label for="wpstats_rated_highest_page">'.esc_html(sprintf(_n('%s Highest Rated Page', '%s Highest Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     }
     if($stats_display['rated_most_post'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_post" value="rated_most_post" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_most_post">'.sprintf(_n('%s Most Rated Post', '%s Most Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_post" value="rated_most_post" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_most_post">'.esc_html(sprintf(_n('%s Most Rated Post', '%s Most Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_post" value="rated_most_post" />&nbsp;&nbsp;<label for="wpstats_rated_most_post">'.sprintf(_n('%s Most Rated Post', '%s Most Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_post" value="rated_most_post" />&nbsp;&nbsp;<label for="wpstats_rated_most_post">'.esc_html(sprintf(_n('%s Most Rated Post', '%s Most Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     }
     if($stats_display['rated_most_page'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_page" value="rated_most_page" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_most_page">'.sprintf(_n('%s Most Rated Page', '%s Most Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_page" value="rated_most_page" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_most_page">'.esc_html(sprintf(_n('%s Most Rated Page', '%s Most Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_page" value="rated_most_page" />&nbsp;&nbsp;<label for="wpstats_rated_most_page">'.sprintf(_n('%s Most Rated Page', '%s Most Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit)).'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_page" value="rated_most_page" />&nbsp;&nbsp;<label for="wpstats_rated_most_page">'.esc_html(sprintf(_n('%s Most Rated Page', '%s Most Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
     }
     return $content;
 }
@@ -843,9 +843,9 @@ function postratings_page_admin_most_stats($content) {
 function postratings_page_general_stats($content) {
     $stats_display = get_option('stats_display');
     if($stats_display['ratings'] == 1) {
-        $content .= '<p><strong>'.__('WP-PostRatings', 'wp-postratings').'</strong></p>'."\n";
+        $content .= '<p><strong>'.esc_html__('WP-PostRatings', 'wp-postratings').'</strong></p>'."\n";
         $content .= '<ul>'."\n";
-        $content .= '<li>'.sprintf(_n('%s user casted his vote.', '%s users casted their vote.', get_ratings_users(false), 'wp-postratings'), '<strong>'.number_format_i18n(get_ratings_users(false)).'</strong>').'</li>'."\n";
+        $content .= '<li>'.esc_html(sprintf(_n('%s user casted his vote.', '%s users casted their vote.', get_ratings_users(false), 'wp-postratings'), '<strong>'.number_format_i18n(get_ratings_users(false)).'</strong>')).'</li>'."\n";
         $content .= '</ul>'."\n";
     }
     return $content;
@@ -1084,10 +1084,10 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
         if($post_ratings_score > 0) {
             $post_ratings_score = '+'.$post_ratings_score;
         }
-        $post_ratings_alt_text = sprintf(_n('%s rating', '%s ratings', $post_ratings_score, 'wp-postratings'), number_format_i18n($post_ratings_score)).__(',', 'wp-postratings').' '.sprintf(_n('%s vote', '%s votes', $post_ratings_users, 'wp-postratings'), number_format_i18n($post_ratings_users));
+        $post_ratings_alt_text = esc_html(sprintf(_n('%s rating', '%s ratings', $post_ratings_score, 'wp-postratings'), number_format_i18n($post_ratings_score)).__(',', 'wp-postratings').' '.sprintf(_n('%s vote', '%s votes', $post_ratings_users, 'wp-postratings'), number_format_i18n($post_ratings_users)));
     } else {
         $post_ratings_score = number_format_i18n($post_ratings_score);
-        $post_ratings_alt_text = sprintf(_n('%s vote', '%s votes', $post_ratings_users, 'wp-postratings'), number_format_i18n($post_ratings_users)).__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': '.number_format_i18n($post_ratings_average, 2).' '.__('out of', 'wp-postratings').' '.number_format_i18n($ratings_max);
+        $post_ratings_alt_text = esc_html(sprintf(_n('%s vote', '%s votes', $post_ratings_users, 'wp-postratings'), number_format_i18n($post_ratings_users)).__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': '.number_format_i18n($post_ratings_average, 2).' '.__('out of', 'wp-postratings').' '.number_format_i18n($ratings_max));
     }
     // Check for half star
     $insert_half = 0;

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -98,7 +98,7 @@ function the_ratings($start_tag = 'div', $custom_id = 0, $display = true) {
     $postratings_ajax_style = get_option('postratings_ajax_style');
     if(intval($postratings_ajax_style['loading']) == 1) {
         $loading = '<' . $start_tag . ' id="post-ratings-' . $ratings_id . '-loading" class="post-ratings-loading">
-            <img src="' . plugins_url('wp-postratings/images/loading.gif') . '" width="16" height="16" class="post-ratings-image" />' . __( 'Loading...', 'wp-postratings' ) . '</' . $start_tag . '>';
+            <img src="' . plugins_url('wp-postratings/images/loading.gif') . '" width="16" height="16" class="post-ratings-image" />' . esc_html__( 'Loading...', 'wp-postratings' ) . '</' . $start_tag . '>';
     } else {
         $loading = '';
     }
@@ -470,7 +470,7 @@ if(!function_exists('snippet_text')) {
 ### Function: Process Post Excerpt, For Some Reasons, The Default get_post_excerpt() Does Not Work As Expected
 function ratings_post_excerpt($post_id, $post_excerpt, $post_content) {
     if( post_password_required( $post_id ) ) {
-        return __( 'There is no excerpt because this is a protected post.', 'wp-postratings' );
+        return esc_html__( 'There is no excerpt because this is a protected post.', 'wp-postratings' );
     }
     if(empty($post_excerpt)) {
         return snippet_text( strip_tags( strip_shortcodes( $post_content ) ), 200 );
@@ -519,7 +519,7 @@ function process_ratings() {
         // Verify Referer
         if(!check_ajax_referer('postratings_'.$post_id.'-nonce', 'postratings_'.$post_id.'_nonce', false))
         {
-            _e('Failed To Verify Referrer', 'wp-postratings');
+            esc_html_e('Failed To Verify Referrer', 'wp-postratings');
             exit();
         }
 
@@ -582,11 +582,11 @@ function process_ratings() {
                     echo the_ratings_results($post_id, $post_ratings_users, $post_ratings_score, $post_ratings_average);
                     exit();
                 } else {
-                    printf(__('Invalid Post ID (#%s).', 'wp-postratings'), $post_id);
+                    printf(esc_html__('Invalid Post ID (#%s).', 'wp-postratings'), $post_id);
                     exit();
                 } // End if($post)
             } else {
-                printf(__('You Had Already Rated This Post. Post ID #%s.', 'wp-postratings'), $post_id);
+                printf(esc_html__('You Had Already Rated This Post. Post ID #%s.', 'wp-postratings'), $post_id);
                 exit();
             }// End if(!$rated)
         } // End if($rate && $post_id && check_allowtorate())
@@ -634,9 +634,9 @@ function manage_ratings()
         <table class="form-table">
             <thead>
                 <tr>
-                    <th><?php _e('Rating Image', 'wp-postratings'); ?></th>
-                    <th><?php _e('Rating Text', 'wp-postratings'); ?></th>
-                    <th><?php _e('Rating Value', 'wp-postratings'); ?></th>
+                    <th><?php esc_html_e('Rating Image', 'wp-postratings'); ?></th>
+                    <th><?php esc_html_e('Rating Text', 'wp-postratings'); ?></th>
+                    <th><?php esc_html_e('Rating Value', 'wp-postratings'); ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -803,9 +803,9 @@ function postratings_wp_stats() {
 function postratings_page_admin_general_stats($content) {
     $stats_display = get_option('stats_display');
     if($stats_display['ratings'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_ratings" value="ratings" checked="checked" />&nbsp;&nbsp;<label for="wpstats_ratings">'.__('WP-PostRatings', 'wp-postratings').'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_ratings" value="ratings" checked="checked" />&nbsp;&nbsp;<label for="wpstats_ratings">'.esc_html__('WP-PostRatings', 'wp-postratings').'</label><br />'."\n";
     } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_ratings" value="ratings" />&nbsp;&nbsp;<label for="wpstats_ratings">'.__('WP-PostRatings', 'wp-postratings').'</label><br />'."\n";
+        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_ratings" value="ratings" />&nbsp;&nbsp;<label for="wpstats_ratings">'.esc_html__('WP-PostRatings', 'wp-postratings').'</label><br />'."\n";
     }
     return $content;
 }

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -611,7 +611,7 @@ function manage_ratings()
 
         // Form Processing
         $postratings_customrating = intval($_GET['custom']);
-        $postratings_image = trim($_GET['image']);
+        $postratings_image = sanitize_file_name(trim($_GET['image']));
         $postratings_max = intval($_GET['max']);
 
         // If It Is A Up/Down Rating
@@ -887,6 +887,8 @@ function postratings_page_most_stats($content) {
 ### Function: Gets HTML of rating images
 function get_ratings_images($ratings_custom, $ratings_max, $post_rating, $ratings_image, $image_alt, $insert_half) {
     $ratings_images = '';
+    $image_alt = esc_attr( $image_alt );
+    $ratings_image = sanitize_file_name( $ratings_image );
     $image_alt = apply_filters( 'wp_postratings_ratings_image_alt', $image_alt );
     if(is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT)) {
         $ratings_images .= '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
@@ -934,6 +936,7 @@ function get_ratings_images($ratings_custom, $ratings_max, $post_rating, $rating
 ### Function: Gets HTML of rating images for voting
 function get_ratings_images_vote($post_id, $ratings_custom, $ratings_max, $post_rating, $ratings_image, $image_alt, $insert_half, $ratings_texts) {
     $ratings_images = '';
+    $ratings_image = sanitize_file_name( $ratings_image );
     if(is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT)) {
         $ratings_images .= '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
     } elseif(file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_start.'.RATINGS_IMG_EXT)) {
@@ -996,6 +999,8 @@ function get_ratings_images_vote($post_id, $ratings_custom, $ratings_max, $post_
 ### Function: Gets HTML of rating images for comment author
 function get_ratings_images_comment_author($ratings_custom, $ratings_max, $comment_author_rating, $ratings_image, $image_alt) {
     $ratings_images = '';
+    $image_alt = esc_attr( $image_alt );
+    $ratings_image = sanitize_file_name( $ratings_image );
     if(is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT)) {
         $ratings_images .= '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
     } elseif(file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_start.'.RATINGS_IMG_EXT)) {


### PR DESCRIPTION
First of all, thanks for developing this plug-in :). The client is very happy with the functionality.

My apologies that there are lot of little changes here. I've tried to group similar changes into one commit so it's easier to see what each commit is doing.

By far the biggest change, albeit not a particular important one, is to escape translated text, (using `esc_html__` instead of `__`, `esc_html_e` instead of `_e` etc). This prevents a potential attack vector whereby an attacker injects some nefarious HTML into the .po/.mo files. I've never seen this exploited in the wild (translations tend to be reviewed before committing and most .po editors will flag translations that look wrong), but it is a possibility.

Other changes include casting what expect are integers to integers. These values are sometimes used in the HTML mark-up, so by enforcing that they're integers we can be sure they're not injecting any HTML. It might not be exploitable, but this settles the matter for good.

Other, more important changes include: 8933a93 and 9cdeb3b.

The most important changes are 45959e1 and 17b443a. For the former currently, you can insert scripts and iframes in the template files. The only user(s) that can actually do that, however, are admins. But, in a multisite being an admin doesn't necessarily mean the 'site owner', so we do want to impose some restrictions on the user. This commit passes the template through `wp_kses_post()` which basically allows the user to use any HTML tags that they are permitted to use in posts / pages. 

That's the result of my initial sweep over the plug-in, so I'll open another PR for anything else, though I do not suspect that will be much else. 

I'm happy to discuss any of the changes, and why I've suggested them.