### PR TITLE
Add a Bayesian average calculation helper

### DIFF
--- a/includes/postratings-bayesian-score.php
+++ b/includes/postratings-bayesian-score.php
@@ -1,0 +1,81 @@
+<?php
+
+function weighted_score($ns) {
+  $x = 0;
+  $i = 0; // start at 0: 1 star does not count anything in the mean
+  foreach ($ns as $v) {
+    $x += $i * $v;
+    // increase the weight of the next star
+    $i++;
+  }
+  return $x / array_sum($ns);
+}
+
+/*
+  User votes impact (aka "confidence level")
+
+  95%: 11(1.960)/0.5-5.5 = 38 votes
+  90%: 11(1.645)/0.5-5.5 = 31 votes
+  80%: 11(1.282)/0.5-5.5 = 23 votes
+  70%: 11(1.036)/0.5-5.5 = 17 votes
+  60%: 11(0.842)/0.5-5.5 = 13 votes
+  50%: 11(0.674)/0.5-5.5 =  9 votes
+*/
+define('NUM_VOTES_IMPACT_60', 0.842);
+define('NUM_VOTES_IMPACT_80', 1.282);
+define('NUM_VOTES_IMPACT_90', 1.645);
+define('NUM_VOTES_IMPACT_95', 1.960);
+
+// https://stackoverflow.com/a/40958702
+// http://www.evanmiller.org/ranking-items-with-star-ratings.html
+function bayesian_score($ns, $confidence) {
+  $ns = array_reverse($ns);
+  $N = array_sum($ns);
+  $K = count($ns);
+  $s = range($K,1,-1);
+  $s2 = array_map(function($e) {return pow($e, 2);}, $s);
+  $z = $confidence;
+  if (! function_exists('f')) {
+    function f($s, $ns) {
+      $N = array_sum($ns);
+      $K = count($ns);
+      $asum = [];
+      foreach(array_combine($s, $ns) as $sk => $nk) {
+        $asum[] = $sk * ($nk+1);
+      }
+      return array_sum($asum) / ($N+$K);
+    }
+      }
+
+  $fsns = f($s, $ns);
+  return $fsns - $z * sqrt( ( f($s2, $ns) - pow($fsns, 2)) / ($N+$K+1) );
+}
+
+function get_post_score_data($post_id) {
+  global $wpdb;
+
+  $def = [];
+  $f = $wpdb->get_results( $wpdb->prepare( "SELECT rating_rating as r, count(1) as c FROM {$wpdb->ratings} WHERE rating_postid = %d GROUP BY rating_rating", $post_id ));
+  foreach($f as $data) $def[$data->r] = (int)$data->c;
+  $def += array_fill( 1, intval( get_option( 'postratings_max', 5 ) ), 0 );
+  ksort( $def );
+
+  return $def;
+}
+
+function get_bayesian_score($post_id, $confidence) {
+  return bayesian_score( get_post_score_data( $post_id ), $confidence );
+}
+
+
+/* ToDo: how to produce a dynamically generated field (with no stored data at all?)
+   If it's not possible, we may consider (optionnally) storing the alternative average
+   inside the DB too */
+/*
+function get_postrating_bayesian_score($metadata, $object_id, $meta_key, $single) {
+  if ($meta_key && $meta_key == 'bayesian_score') {
+    return get_bayesian_score($object_id, floatval(constant('NUM_VOTES_IMPACT_' . intval(get_option('bayesian_votes_impact', 90)))) ? : NUM_VOTES_IMPACT_90);
+  }
+}
+add_filter('get_post_metadata', 'get_postrating_bayesian_score', 10, 4);
+*/

--- a/includes/postratings-tests.php
+++ b/includes/postratings-tests.php
@@ -1,0 +1,44 @@
+<?php
+
+// wp eval "include('$PWD/includes/postratings-tests.php'); get_post_rating_detail();"
+// output results comparing the above two rating functions
+function postratings_score_tests($confidence = NUM_VOTES_IMPACT_90, $arr = null) {
+  $tests = array(
+    [0,0,0,20,0], // 20x 4 stars
+    [0,0,20,0,0],
+    [10,0,0,0,10],
+    [0,0,0,10,0],
+    [0,0,25,15,4],
+    [0,0,10,0,0], // 10x 3 start
+    [0,0,0,0,1], // 5 stars
+    [0,0,30,0,0],
+    [0,0,0,0,10],
+  );
+
+  printf("## Confidence = %.3f\n", $confidence);
+  printf("% 7sstars% 8s \t| weighted \t bayesian \t diff\n", "", "");
+  print(str_repeat("-", 61) . "\n");
+  foreach($arr ? : $tests as $ns) {
+    $w = weighted_score($ns);
+    $b = bayesian_score($ns, $confidence);
+    // diff, floored at quarter
+    $d = floor(($b - $w) * 4)/4;
+
+    printf("%s \t| %.3f \t %.3f \t %s%s\n",
+           implode(',', array_map(function($e){return sprintf("% 3d",$e);}, $ns)),
+           $w, $b, /*$fw,*/
+           ($d > 0 ? "\t " : ($d < 0 ? "\t" : '')),
+           $d != 0 ? sprintf("%.2f", $d) : "");
+  }
+}
+
+function get_post_rating_detail($stats) {
+  global $wpdb;
+
+  $post_stats = [];
+  foreach($wpdb->get_results("SELECT distinct rating_postid as p FROM {$wpdb->ratings}") as $i) {
+    $post_stats[] = get_post_score_data($i->p);
+  }
+
+  postratings_score_tests(NUM_VOTES_IMPACT_90, $post_stats);
+}

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -61,6 +61,7 @@ require_once( 'includes/postratings-shortcodes.php' );
 require_once( 'includes/postratings-stats.php' );
 require_once( 'includes/postratings-widgets.php' );
 require_once( 'includes/postratings-comment.php' );
+require_once( 'includes/postratings-bayesian-score.php' );
 
 /**
  * Register plugin activation hook


### PR DESCRIPTION
 Avoid little-evaluated high-noted items to overcome vastly-evaluated items.
Ex with (0,2,3,11,5) vs (0,0,3,1,3):
* Traditional scoring: 2.9 vs 3.2.
* Bayesian scoring with 90% confidence: 3.4 vs 3.0
("Bayesian" may not be the best word for it but still)

Some more samples of this algorithm change:
For little-evaluated items:
```
## Confidence = 1.645 (90%)
       stars         	| weighted 	 bayesian 	 diff
-------------------------------------------------------------
  1,  0,  0,  0,  0 	| 0.000 	 1.740 	 	 1.50
  2,  0,  0,  0,  0 	| 0.000 	 1.557 	 	 1.50
  1,  2,  0,  0,  0 	| 0.667 	 1.775 	 	 1.00
  0,  0,  0,  0,  1 	| 4.000 	 2.406 	 	-1.75
  0,  0,  0,  0,  2 	| 4.000 	 2.700 	 	-1.50
  0,  0,  0,  0,  3 	| 4.000 	 2.939 	 	-1.25
  0,  0,  0,  0,  4 	| 4.000 	 3.135 	 	-1.00
  0,  0,  0,  1,  1 	| 3.500 	 2.615 	 	-1.00
  0,  0,  0,  1,  2 	| 3.667 	 2.853 	 	-1.00
  1,  0,  0,  1,  4 	| 3.167 	 2.899 	 	-0.50
  2,  0,  4, 13, 15 	| 3.147 	 3.700 	 	 0.50
  1,  1,  7, 12, 20 	| 3.195 	 3.803 	 	 0.50
  1, 11, 18, 12, 12 	| 2.426 	 3.149 	 	 0.50
  0,  4, 27, 26, 16 	| 2.740 	 3.521 	 	 0.75
  0,  1, 13, 18, 28 	| 3.217 	 3.930 	 	 0.50
```

I didn't found nor imposed a way to integrate this.
Having "virtual" fields (generated on-demand) would be nice but `get_post_metadata()` didn't make it.
Feel free to use/call the helper the way you want.
NB: it lacks the ability to fetch the Bayesian average for multiple posts at once

All credit goes to
http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
https://stackoverflow.com/questions/1411199/what-is-a-better-way-to-sort-by-a-5-star-rating/40958702