### PR TITLE
code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ N/A
 ## Frequently Asked Questions
 
 ### How To Change Schema Type?
-The default schema type is 'Article', if you want to change it to 'Recipe', you need to make use of the `wp_postratings_schema_itemtype` filter as shown in the sample code below:
 
 ```php
 <?php  
@@ -163,8 +162,9 @@ function wp_postratings_schema_itemtype( $itemtype ) {
 ?>
 ```
 
+The default schema type is 'Article', if you want to change it to 'Recipe', you need to make use of the `wp_postratings_schema_itemtype` filter as shown in the sample code above.
+
 ### How To Add Your Site Logo For Google Rich Snippets
-By default, the plugin will use your site header image URL as your site logo. If you want to change it, you need to make use of the `wp_postratings_site_logo` filter as shown in the sample code below:
 
 ```php
 <?php  
@@ -174,6 +174,8 @@ function wp_postratings_site_logo( $url ) {
 }  
 ?>
 ```
+
+By default, the plugin will use your site header image URL as your site logo. If you want to change it, you need to make use of the `wp_postratings_site_logo` filter as shown in the sample code above.
 
 ### How To Remove Ratings Image alt and title Text?
 
@@ -187,14 +189,14 @@ function wp_postratings_ratings_image_alt( $alt_title_text ) {
 ```
 
 ### How To Display Comment Author Ratings?
-By default, the comment author ratings are not displayed. If you want to display the ratings, you need to make use of the `wp_postratings_display_comment_author_ratings` filter as shown in the sample code below:
 
 ```php
 add_filter( 'wp_postratings_display_comment_author_ratings', '__return_true' );
 ```
 
+By default, the comment author ratings are not displayed. If you want to display the ratings, you need to make use of the `wp_postratings_display_comment_author_ratings` filter as shown in the sample code above.
+
 ### How To use PNG images instead of GIF images?
-The default image extension if 'gif', if you want to change it to 'png', you need to make use of the `wp_postratings_image_extension` filter as shown in the sample code below:
 
 ```php
 function custom_rating_image_extension() {
@@ -203,8 +205,9 @@ function custom_rating_image_extension() {
 add_filter( 'wp_postratings_image_extension', 'custom_rating_image_extension' );
 ```
 
+The default image extension if 'gif', if you want to change it to 'png', you need to make use of the `wp_postratings_image_extension` filter as shown in the sample code above.
+
 ### How To change the cookie expiration time?
-The default cookie expiration if 'time() + 30000000', if you want to change the lenght of the experation, you need to make use of the `wp_postratings_cookie_expiration` filter as shown in the sample code below:
 
 ```php
 function custom_rating_cookie_expiration() {
@@ -212,6 +215,8 @@ function custom_rating_cookie_expiration() {
 }
 add_filter( 'wp_postratings_cookie_expiration', 'custom_rating_cookie_expiration', 10, 0 );
 ```
+
+The default cookie expiration if 'time() + 30000000', if you want to change the lenght of the experation, you need to make use of the `wp_postratings_cookie_expiration` filter as shown in the sample code above.
 
 ### How Does WP-PostRatings Load CSS?
 * WP-PostRatings will load `postratings-css.css` from your theme's CSS directory if it exists.
@@ -240,6 +245,7 @@ add_filter( 'wp_postratings_cookie_expiration', 'custom_rating_cookie_expiration
 * The value 10 will display only the top 10 lowest rated posts/pages.
 
 ### To Display Lowest Rated Post By Tag
+
 ```php
 <?php if (function_exists('get_lowest_rated_tag')): ?>
 	<ul>
@@ -257,6 +263,7 @@ add_filter( 'wp_postratings_cookie_expiration', 'custom_rating_cookie_expiration
 * The value 10 will display only the top 10 lowest rated posts/pages.
 
 ### To Display Lowest Rated Post In A Category
+
 ```php
 <?php if (function_exists('get_lowest_rated_category')): ?>
 	<ul>

--- a/includes/postratings-scripts.php
+++ b/includes/postratings-scripts.php
@@ -61,12 +61,12 @@ function ratings_scripts_admin($hook_suffix) {
 }
 
 // this need to be triggered manually
-function ratings_script_config() {
+function ratings_script_config($ajax = TRUE) {
     $postratings_ajax_style = get_option( 'postratings_ajax_style' );
 
     wp_localize_script('wp-postratings', 'ratingsL10n', array(
         'plugin_url' => plugins_url( 'wp-postratings' ),
-        'ajax_url' => admin_url('admin-ajax.php'),
+        'ajax_url' => $ajax ? admin_url('admin-ajax.php') : FALSE,
         'text_wait' => __('Please rate only 1 item at a time.', 'wp-postratings'),
         'image' => get_option( 'postratings_image' ),
         'image_ext' => RATINGS_IMG_EXT,

--- a/includes/postratings-scripts.php
+++ b/includes/postratings-scripts.php
@@ -42,32 +42,8 @@ function ratings_scripts() {
             wp_enqueue_style( 'wp-postratings-rtl', plugins_url( 'wp-postratings/css/postratings-css-rtl.css' ), false, WP_POSTRATINGS_VERSION, 'all' );
         }
     }
-    $postratings_max = intval( get_option( 'postratings_max' ) );
-    $postratings_custom = intval( get_option( 'postratings_customrating' ) );
-    $postratings_ajax_style = get_option( 'postratings_ajax_style' );
-    $postratings_image = get_option( 'postratings_image' );
-    $postratings_plugins_url = plugins_url( 'wp-postratings' );
-    $postratings_javascript = '';
-    if($postratings_custom) {
-        for($i = 1; $i <= $postratings_max; $i++) {
-            $postratings_javascript .= 'var ratings_' . $i . '_mouseover_image=new Image();ratings_' . $i . '_mouseover_image.src="' . $postratings_plugins_url . '/images/' . $postratings_image . '/rating_' . $i . '_over.' . RATINGS_IMG_EXT . '";';
-        }
-    } else {
-        $postratings_javascript = 'var ratings_mouseover_image=new Image();ratings_mouseover_image.src="' . $postratings_plugins_url . '/images/' . $postratings_image . '/rating_over.' . RATINGS_IMG_EXT . '";';
-    }
-    wp_enqueue_script('wp-postratings', plugins_url('wp-postratings/js/postratings-js.js'), array('jquery'), WP_POSTRATINGS_VERSION, true);
-    wp_localize_script('wp-postratings', 'ratingsL10n', array(
-        'plugin_url' => $postratings_plugins_url,
-        'ajax_url' => admin_url('admin-ajax.php'),
-        'text_wait' => __('Please rate only 1 item at a time.', 'wp-postratings'),
-        'image' => $postratings_image,
-        'image_ext' => RATINGS_IMG_EXT,
-        'max' => $postratings_max,
-        'show_loading' => intval($postratings_ajax_style['loading']),
-        'show_fading' => intval($postratings_ajax_style['fading']),
-        'custom' => $postratings_custom,
-        'l10n_print_after' => $postratings_javascript
-    ));
+
+    wp_enqueue_script('wp-postratings', plugins_url('wp-postratings/js/postratings-js.dev.js'), array('jquery'), WP_POSTRATINGS_VERSION, true);
 }
 
 
@@ -82,4 +58,21 @@ function ratings_scripts_admin($hook_suffix) {
             'admin_ajax_url' => admin_url('admin-ajax.php')
         ));
     }
+}
+
+// this need to be triggered manually
+function ratings_script_config() {
+    $postratings_ajax_style = get_option( 'postratings_ajax_style' );
+
+    wp_localize_script('wp-postratings', 'ratingsL10n', array(
+        'plugin_url' => plugins_url( 'wp-postratings' ),
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'text_wait' => __('Please rate only 1 item at a time.', 'wp-postratings'),
+        'image' => get_option( 'postratings_image' ),
+        'image_ext' => RATINGS_IMG_EXT,
+        'max' => intval( get_option( 'postratings_max' ) ),
+        'show_loading' => intval($postratings_ajax_style['loading']),
+        'show_fading' => intval($postratings_ajax_style['fading']),
+        'custom' => boolval( get_option( 'postratings_customrating', false ) ),
+    ));
 }

--- a/js/postratings-js.dev.js
+++ b/js/postratings-js.dev.js
@@ -17,65 +17,59 @@
 
 
 // Variables
-var post_id = 0;
-var post_rating = 0;
+var $j = jQuery.noConflict();
 var is_being_rated = false;
 ratingsL10n.custom = parseInt(ratingsL10n.custom);
 ratingsL10n.max = parseInt(ratingsL10n.max);
 ratingsL10n.show_loading = parseInt(ratingsL10n.show_loading);
 ratingsL10n.show_fading = parseInt(ratingsL10n.show_fading);
 
+
+var ratings_mouseover_image;
+if(ratingsL10n.custom) {
+	ratings_mouseover_image = [];
+        for(var i = 1; i <= ratingsL10n.max; i++) {
+		ratings_mouseover_image[i] = new Image();
+		ratings_mouseover_image[i].src = ratingsL10n.plugin_url + "/images/" + ratingsL10n.image + "/rating_" + i + "_over." + ratingsL10n.image_ext ;
+        }
+} else {
+	ratings_mouseover_image = new Image();
+	ratings_mouseover_image.src = ratingsL10n.plugin_url + "/images/" + ratingsL10n.image + "/rating_over."  + ratingsL10n.image_ext ;
+}
+
 // When User Mouse Over Ratings
-function current_rating(id, rating, rating_text) {
+function current_rating(post_id, post_rating, rating_text) {
 	if(!is_being_rated) {
-		post_id = id;
-		post_rating = rating;
 		if(ratingsL10n.custom && ratingsL10n.max == 2) {
-			jQuery('#rating_' + post_id + '_' + rating).attr('src', eval('ratings_' + rating + '_mouseover_image.src'));
+			document.getElementById('rating_' + post_id + '_' + post_rating).src = ratings_mouseover_image[i].src;
 		} else {
-			for(i = 1; i <= rating; i++) {
-				if(ratingsL10n.custom) {
-					jQuery('#rating_' + post_id + '_' + i).attr('src', eval('ratings_' + i + '_mouseover_image.src'));
-				} else {
-					jQuery('#rating_' + post_id + '_' + i).attr('src', ratings_mouseover_image.src);
-				}
+			for(var i = 1; i <= post_rating; i++) {
+				console.log("#" + 'rating_' + post_id + '_' + i + ' = ' + ratings_mouseover_image.src);
+				document.getElementById('rating_' + post_id + '_' + i).src = ratingsL10n.custom ? ratings_mouseover_image[i].src : ratings_mouseover_image.src;
 			}
 		}
 		if(jQuery('#ratings_' + post_id + '_text').length) {
-			jQuery('#ratings_' + post_id + '_text').show();
-			jQuery('#ratings_' + post_id + '_text').html(rating_text);
+			jQuery('#ratings_' + post_id + '_text').html(rating_text).show();
 		}
 	}
 }
 
-
 // When User Mouse Out Ratings
-function ratings_off(rating_score, insert_half, half_rtl) {
+function ratings_off(post_id, rating_score, insert_half, half_rtl) {
 	if(!is_being_rated) {
-		for(i = 1; i <= ratingsL10n.max; i++) {
+		var baseimg = ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating' ;
+		for(var i = 1; i <= ratingsL10n.max; i++) {
+			var element = document.getElementById('rating_' + post_id + '_' + i);
 			if(i <= rating_score) {
-				if(ratingsL10n.custom) {
-					jQuery('#rating_' + post_id + '_' + i).attr('src', ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating_' + i + '_on.' + ratingsL10n.image_ext);
-				} else {
-					jQuery('#rating_' + post_id + '_' + i).attr('src', ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating_on.' + ratingsL10n.image_ext);
-				}
+				element.src = baseimg + (ratingsL10n.custom ? '_' + i : '') + '_on.' + ratingsL10n.image_ext;
 			} else if(i == insert_half) {
-				if(ratingsL10n.custom) {
-					jQuery('#rating_' + post_id + '_' + i).attr('src',  ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating_' + i + '_half' + (half_rtl ? '-rtl' : '') + '.' + ratingsL10n.image_ext);
-				} else {
-					jQuery('#rating_' + post_id + '_' + i).attr('src', ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating_half' + (half_rtl ? '-rtl' : '') + '.' + ratingsL10n.image_ext);
-				}
+				element.src = baseimg + (ratingsL10n.custom ? '_' + i : '') + '_half' + (half_rtl ? '-rtl' : '') + '.' + ratingsL10n.image_ext;
 			} else {
-				if(ratingsL10n.custom) {
-					jQuery('#rating_' + post_id + '_' + i).attr('src', ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating_' + i + '_off.' + ratingsL10n.image_ext);
-				} else {
-					jQuery('#rating_' + post_id + '_' + i).attr('src', ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating_off.' + ratingsL10n.image_ext);
-				}
+				element.src = baseimg + (ratingsL10n.custom ? '_' + i : '') + '_off.' + ratingsL10n.image_ext;
 			}
 		}
 		if(jQuery('#ratings_' + post_id + '_text').length) {
-			jQuery('#ratings_' + post_id + '_text').hide();
-			jQuery('#ratings_' + post_id + '_text').empty();
+			jQuery('#ratings_' + post_id + '_text').hide().empty();
 		}
 	}
 }
@@ -86,13 +80,13 @@ function set_is_being_rated(rated_status) {
 }
 
 // Process Post Ratings Success
-function rate_post_success(data) {
-	jQuery('#post-ratings-' + post_id).html(data);
+function rate_post_success(post_id, data) {
+	$j('#post-ratings-' + post_id).html(data);
 	if(ratingsL10n.show_loading) {
-		jQuery('#post-ratings-' + post_id + '-loading').hide();
+		$j('#post-ratings-' + post_id + '-loading').hide();
 	}
 	if(ratingsL10n.show_fading) {
-		jQuery('#post-ratings-' + post_id).fadeTo('def', 1, function () {
+		$j('#post-ratings-' + post_id).fadeTo('def', 1, function () {
 			set_is_being_rated(false);
 		});
 	} else {
@@ -101,27 +95,33 @@ function rate_post_success(data) {
 }
 
 // Process Post Ratings
-function rate_post() {
-	post_ratings_el = jQuery('#post-ratings-' + post_id);
+function rate_post(post_id, post_rating) {
+	var post_ratings_el = $j('#post-ratings-' + post_id);
 	if(!is_being_rated) {
-		post_ratings_nonce = jQuery(post_ratings_el).data('nonce');
+		var post_ratings_nonce = $j(post_ratings_el).data('nonce');
 		if(typeof post_ratings_nonce == 'undefined' || post_ratings_nonce == null)
-			post_ratings_nonce = jQuery(post_ratings_el).attr('data-nonce');
+			post_ratings_nonce = $j(post_ratings_el).attr('data-nonce');
 		set_is_being_rated(true);
 		if(ratingsL10n.show_fading) {
-			jQuery(post_ratings_el).fadeTo('def', 0, function () {
+			$j(post_ratings_el).fadeTo('def', 0, function () {
 				if(ratingsL10n.show_loading) {
-					jQuery('#post-ratings-' + post_id + '-loading').show();
+					$j('#post-ratings-' + post_id + '-loading').show();
 				}
-				jQuery.ajax({type: 'POST', xhrFields: {withCredentials: true}, dataType: 'html', url: ratingsL10n.ajax_url, data: 'action=postratings&pid=' + post_id + '&rate=' + post_rating + '&postratings_' + post_id + '_nonce=' + post_ratings_nonce, cache: false, success: rate_post_success});
 			});
 		} else {
 			if(ratingsL10n.show_loading) {
-				jQuery('#post-ratings-' + post_id + '-loading').show();
+				$j('#post-ratings-' + post_id + '-loading').show();
 			}
-			jQuery.ajax({type: 'POST', xhrFields: {withCredentials: true}, dataType: 'html', url: ratingsL10n.ajax_url, data: 'action=postratings&pid=' + post_id + '&rate=' + post_rating + '&postratings_' + post_id + '_nonce=' + post_ratings_nonce, cache: false, success: rate_post_success});
 		}
-	} else {
+		$j.post({xhrFields: {withCredentials: true},
+			 dataType: 'html',
+			 url: ratingsL10n.ajax_url,
+			 data: 'action=postratings&pid=' + post_id + '&rate=' + post_rating + '&postratings_' + post_id + '_nonce=' + post_ratings_nonce,
+			 cache: false})
+			.done(function(data) { rate_post_success(post_id, data); });
+	}
+
+	else {
 		alert(ratingsL10n.text_wait);
 	}
 }

--- a/js/postratings-js.dev.js
+++ b/js/postratings-js.dev.js
@@ -39,6 +39,14 @@ if(ratingsL10n.custom) {
 
 // When User Mouse Over Ratings
 function current_rating(post_id, post_rating) {
+	if (! ratingsL10n.ajax_url) {
+		var element = $j('input[name="wp_postrating_form_value_' + post_id + '"]');
+		// mouseout, but a value was click/selected in order to be later POSTed: do nothing
+		if (parseInt($j(element).val())) {
+			return;
+		}
+	}
+
 	if(!is_being_rated) {
 		if(ratingsL10n.custom && ratingsL10n.max == 2) {
 			document.getElementById('rating_' + post_id + '_' + post_rating).src = ratings_mouseover_image[i].src;
@@ -55,10 +63,20 @@ function current_rating(post_id, post_rating) {
 
 // When User Mouse Out Ratings
 function ratings_off(post_id, rating_score, insert_half, half_rtl) {
+	var element;
+
+	if (! ratingsL10n.ajax_url) {
+		element = $j('input[name="wp_postrating_form_value_' + post_id + '"]');
+		// mouseout, but a value was click/selected in order to be later POSTed: do nothing
+		if (parseInt($j(element).val())) {
+			return;
+		}
+	}
+
 	if(!is_being_rated) {
 		var baseimg = ratingsL10n.plugin_url + '/images/' + ratingsL10n.image + '/rating' ;
 		for(var i = 1; i <= ratingsL10n.max; i++) {
-			var element = document.getElementById('rating_' + post_id + '_' + i);
+			element = document.getElementById('rating_' + post_id + '_' + i);
 			if(i <= rating_score) {
 				element.src = baseimg + (ratingsL10n.custom ? '_' + i : '') + '_on.' + ratingsL10n.image_ext;
 			} else if(i == insert_half) {
@@ -96,6 +114,18 @@ function rate_post_success(post_id, data) {
 // Process Post Ratings
 function rate_post(post_id, post_rating) {
 	var post_ratings_el = $j('#post-ratings-' + post_id);
+	if (! ratingsL10n.ajax_url) {
+		var value_holder = $j('input[name="wp_postrating_form_value_' + post_id + '"]');
+		var curval = $j(value_holder).val();
+		$j(value_holder).val(null);
+		$j('#rating_' + post_id + '_' + curval).trigger('mouseout');
+		if (curval != post_rating) {
+			$j('#rating_' + post_id + '_' + post_rating).trigger('mouseover');
+			$j(value_holder).val(post_rating);
+		}
+		return;
+	}
+
 	if(!is_being_rated) {
 		var post_ratings_nonce = $j(post_ratings_el).data('nonce');
 		if(typeof post_ratings_nonce == 'undefined' || post_ratings_nonce == null)

--- a/js/postratings-js.dev.js
+++ b/js/postratings-js.dev.js
@@ -38,18 +38,17 @@ if(ratingsL10n.custom) {
 }
 
 // When User Mouse Over Ratings
-function current_rating(post_id, post_rating, rating_text) {
+function current_rating(post_id, post_rating) {
 	if(!is_being_rated) {
 		if(ratingsL10n.custom && ratingsL10n.max == 2) {
 			document.getElementById('rating_' + post_id + '_' + post_rating).src = ratings_mouseover_image[i].src;
 		} else {
 			for(var i = 1; i <= post_rating; i++) {
-				console.log("#" + 'rating_' + post_id + '_' + i + ' = ' + ratings_mouseover_image.src);
 				document.getElementById('rating_' + post_id + '_' + i).src = ratingsL10n.custom ? ratings_mouseover_image[i].src : ratings_mouseover_image.src;
 			}
 		}
 		if(jQuery('#ratings_' + post_id + '_text').length) {
-			jQuery('#ratings_' + post_id + '_text').html(rating_text).show();
+			jQuery('#ratings_' + post_id + '_text').html(jQuery('#rating_' + post_id + '_' + post_rating).data('ratingsText')).show();
 		}
 	}
 }

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -60,6 +60,7 @@ if ( isset( $_POST['Submit'] ) ) {
 
     $postratings_ajax_style = array('loading' => intval($_POST['postratings_ajax_style_loading']), 'fading' => intval($_POST['postratings_ajax_style_fading']));
     $postratings_logging_method = intval($_POST['postratings_logging_method']);
+    $postratings_onlyifcomment = intval($_POST['postratings_onlyifcomment']);
     $postratings_allowtorate = intval($_POST['postratings_allowtorate']);
     $update_ratings_queries = array();
     $update_ratings_text = array();
@@ -77,6 +78,7 @@ if ( isset( $_POST['Submit'] ) ) {
     $update_ratings_queries[] = update_option('postratings_ratingsvalue', $postratings_ratingsvalue);
     $update_ratings_queries[] = update_option('postratings_ajax_style', $postratings_ajax_style);
     $update_ratings_queries[] = update_option('postratings_logging_method', $postratings_logging_method);
+    $update_ratings_queries[] = update_option('postratings_onlyifcomment', $postratings_onlyifcomment);
     $update_ratings_queries[] = update_option('postratings_allowtorate', $postratings_allowtorate);
     $update_ratings_queries[] = update_option('postratings_options', $postratings_options);
     $update_ratings_text[] = __('Custom Rating', 'wp-postratings');
@@ -384,6 +386,22 @@ $postratings_image = get_option('postratings_image');
                     </select>
                 </td>
             </tr>
+
+        <h2><?php esc_html_e('Post rating integration', 'wp-postratings'); ?></h2>
+        <table class="form-table">
+             <?php if (get_option('default_comment_status') == 'open'): ?>
+             <tr>
+                <th scope="row" valign="top"><?php esc_html_e('Restrict rating to comment submission?', 'wp-postratings'); ?></th>
+                <td>
+                    <select name="postratings_onlyifcomment" size="1">
+                        <option value="0"<?php selected('0', get_option('postratings_onlyifcomment')); ?>><?php esc_html_e('No', 'wp-postratings'); ?></option>
+                        <option value="1"<?php selected('1', get_option('postratings_onlyifcomment')); ?>><?php esc_html_e('Yes', 'wp-postratings'); ?></option>
+                    </select>
+                </td>
+            </tr>
+            <?php endif; ?>
+        </table>
+
         </table>
         <h2><?php esc_html_e('Allow To Rate', 'wp-postratings'); ?></h2>
         <table class="form-table">

--- a/uninstall.php
+++ b/uninstall.php
@@ -12,6 +12,7 @@ $option_names = array(
 	, 'postratings_template_text'
 	, 'postratings_template_none'
 	, 'postratings_logging_method'
+	, 'postratings_onlyifcomment'
 	, 'postratings_allowtorate'
 	, 'postratings_ratingstext'
 	, 'postratings_template_highestrated'

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -75,7 +75,13 @@ function postratings_init() {
 }
 
 ### Function: Display The Rating For The Post
-function the_ratings($start_tag = 'div', $custom_id = 0, $display = true) {
+function the_ratings($start_tag = 'div', $custom_id = 0, $display = true /* obsolete */) {
+  if ($display) echo get_the_ratings($start_tag, $custom_id);
+  else return get_the_ratings($start_tag, $custom_id);
+}
+
+### Function: Get The Rating For The Post
+function get_the_ratings($start_tag = 'div', $custom_id = 0) {
     global $id;
     // Allow Custom ID
     if(intval($custom_id) > 0) {
@@ -113,27 +119,21 @@ function the_ratings($start_tag = 'div', $custom_id = 0, $display = true) {
     } else {
         $attributes = 'id="post-ratings-'.$ratings_id.'" class="post-ratings"';
     }
+
+
     // If User Voted Or Is Not Allowed To Rate
     if($user_voted) {
-        if(!$display) {
-            return "<$start_tag $attributes>".the_ratings_results($ratings_id).'</'.$start_tag.'>'.$loading;
-        } else {
-            echo "<$start_tag $attributes>".the_ratings_results($ratings_id).'</'.$start_tag.'>'.$loading;
-        }
+      return "<$start_tag $attributes>".the_ratings_results($ratings_id).'</'.$start_tag.'>'.$loading;
     // If User Is Not Allowed To Rate
     } else if(!check_allowtorate()) {
-        if(!$display) {
-            return "<$start_tag $attributes>".the_ratings_results($ratings_id, 0, 0, 0, 1).'</'.$start_tag.'>'.$loading;
-        } else {
-            echo "<$start_tag $attributes>".the_ratings_results($ratings_id, 0, 0, 0, 1).'</'.$start_tag.'>'.$loading;
-        }
+      return "<$start_tag $attributes>".the_ratings_results($ratings_id, 0, 0, 0, 1).'</'.$start_tag.'>'.$loading;
     // If User Has Not Voted
     } else {
-        if(!$display) {
-            return "<$start_tag $attributes data-nonce=\"".wp_create_nonce('postratings_'.$ratings_id.'-nonce')."\">".the_ratings_vote($ratings_id).'</'.$start_tag.'>'.$loading;
-        } else {
-            echo "<$start_tag $attributes data-nonce=\"".wp_create_nonce('postratings_'.$ratings_id.'-nonce')."\">".the_ratings_vote($ratings_id).'</'.$start_tag.'>'.$loading;
-        }
+      ratings_script_config();
+      $html_string = '';
+      $html_string += '<input type="hidden" name="wp_postrating_value" />' . "\n";
+
+      return $html_string .  "<$start_tag $attributes data-nonce=\"".wp_create_nonce('postratings_'.$ratings_id.'-nonce')."\">".the_ratings_vote($ratings_id).'</'.$start_tag.'>'.$loading;
     }
 }
 
@@ -190,15 +190,12 @@ function check_allowtorate() {
         // Guests Only
         case 0:
             return ! is_user_logged_in();
-            break;
         // Logged-in users only
         case 1:
             return is_user_logged_in();
-            break;
         // Users registered on blog (for multisite)
         case 3:
             return is_user_member_of_blog();
-            break;
         // Registered Users And Guests
         case 2:
         default:
@@ -247,11 +244,7 @@ function check_rated( $post_id ) {
 
 ### Function: Check Rated By Cookie
 function check_rated_cookie($post_id) {
-    if(isset($_COOKIE["rated_$post_id"])) {
-        return true;
-    } else {
-        return false;
-    }
+    return (isset($_COOKIE["rated_$post_id"]));
 }
 
 
@@ -391,7 +384,7 @@ if(!function_exists('get_ipaddress')) {
             $ip_address = explode(',', $ip_address);
             $ip_address = $ip_address[0];
         }
-        return esc_attr($ip_address);
+        return $ip_address;
     }
 }
 
@@ -507,21 +500,21 @@ add_action('wp_ajax_nopriv_postratings', 'process_ratings');
 function process_ratings() {
     global $wpdb, $user_identity, $user_ID;
 
-    if(isset($_REQUEST['action']) && $_REQUEST['action'] == 'postratings')
-    {
+    if(isset($_REQUEST['action']) && $_REQUEST['action'] == 'postratings') {
         $rate = intval($_REQUEST['rate']);
         $post_id = intval($_REQUEST['pid']);
 
         // Verify Referer
-        if(!check_ajax_referer('postratings_'.$post_id.'-nonce', 'postratings_'.$post_id.'_nonce', false))
-        {
+        if(!check_ajax_referer('postratings_'.$post_id.'-nonce', 'postratings_'.$post_id.'_nonce', false)) {
             esc_html_e('Failed To Verify Referrer', 'wp-postratings');
             exit();
         }
 
         if($rate > 0 && $post_id > 0 && check_allowtorate()) {
             // Check For Bot
-            $bots_useragent = array('googlebot', 'google', 'msnbot', 'ia_archiver', 'lycos', 'jeeves', 'scooter', 'fast-webcrawler', 'slurp@inktomi', 'turnitinbot', 'technorati', 'yahoo', 'findexa', 'findlinks', 'gaisbo', 'zyborg', 'surveybot', 'bloglines', 'blogsearch', 'ubsub', 'syndic8', 'userland', 'gigabot', 'become.com');
+            $bots_useragent = array('googlebot', 'google', 'msnbot', 'ia_archiver', 'lycos', 'jeeves', 'scooter', 'fast-webcrawler',
+                                    'slurp@inktomi', 'turnitinbot', 'technorati', 'yahoo', 'findexa', 'findlinks', 'gaisbo', 'zyborg',
+                                    'surveybot', 'bloglines', 'blogsearch', 'ubsub', 'syndic8', 'userland', 'gigabot', 'become.com');
             $useragent = $_SERVER['HTTP_USER_AGENT'];
             foreach ($bots_useragent as $bot) {
                 if (stristr($useragent, $bot) !== false) {
@@ -539,7 +532,6 @@ function process_ratings() {
                     $ratings_max = intval(get_option('postratings_max'));
                     $ratings_custom = intval(get_option('postratings_customrating'));
                     $ratings_value = get_option('postratings_ratingsvalue');
-                    $post_title = addslashes($post->post_title);
                     $post_ratings = get_post_custom($post_id);
                     $post_ratings_users = ! empty( $post_ratings['ratings_users'] ) ? intval($post_ratings['ratings_users'][0]) : 0;
                     $post_ratings_score = ! empty( $post_ratings['ratings_score'] ) ? intval($post_ratings['ratings_score'][0]) : 0;
@@ -556,9 +548,9 @@ function process_ratings() {
 
                     // Add Log
                     if(!empty($user_identity)) {
-                        $rate_user = addslashes($user_identity);
+                        $rate_user = $user_identity;
                     } elseif(!empty($_COOKIE['comment_author_'.COOKIEHASH])) {
-                        $rate_user = addslashes($_COOKIE['comment_author_'.COOKIEHASH]);
+                        $rate_user = $_COOKIE['comment_author_'.COOKIEHASH];
                     } else {
                         $rate_user = __('Guest', 'wp-postratings');
                     }
@@ -568,10 +560,25 @@ function process_ratings() {
                     // Only Create Cookie If User Choose Logging Method 1 Or 3
                     $postratings_logging_method = intval(get_option('postratings_logging_method'));
                     if($postratings_logging_method == 1 || $postratings_logging_method == 3) {
-                        $rate_cookie = setcookie("rated_".$post_id, $ratings_value[$rate-1], apply_filters('wp_postratings_cookie_expiration', (time() + 30000000) ), apply_filters('wp_postratings_cookiepath', SITECOOKIEPATH));
+                        $rate_cookie = setcookie("rated_" . $post_id,
+                                                 $ratings_value[$rate-1],
+                                                 apply_filters('wp_postratings_cookie_expiration', (time() + 30000000) ),
+                                                 apply_filters('wp_postratings_cookiepath', SITECOOKIEPATH));
                     }
+
                     // Log Ratings No Matter What
-                    $rate_log = $wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->ratings} VALUES (%d, %d, %s, %d, %d, %s, %s, %s, %d )", 0, $post_id, $post_title, $ratings_value[$rate-1], current_time('timestamp'), get_ipaddress(), @gethostbyaddr( get_ipaddress() ), $rate_user, $rate_userid ) );
+                    $rate_log = $wpdb->insert( $wpdb->prefix . "ratings",
+                                               array(// 'rating_id'        => 0, autoinc
+                                                     'rating_postid'    => $post_id,
+                                                     'rating_posttitle' => $post->post_title,
+                                                     'rating_rating'    => $ratings_value[$rate-1],
+                                                     'rating_timestamp' => current_time('timestamp'),
+                                                     'rating_ip'        => get_ipaddress(),
+                                                     'rating_host'      => @gethostbyaddr( get_ipaddress() ),
+                                                     'rating_username'  => $rate_user,
+                                                     'rating_userid'    => $rate_userid),
+                                               array('%d', '%s', '%d', '%d', '%s', '%s', '%s', '%d') );
+
                     // Allow Other Plugins To Hook When A Post Is Rated
                     do_action('rate_post', $rate_userid, $post_id, $ratings_value[$rate-1]);
                     // Output AJAX Result
@@ -618,11 +625,7 @@ function manage_ratings()
             $postratings_ratingstext[1] = __('Vote Up', 'wp-postratings');
         } else {
             for($i = 0; $i < $postratings_max; $i++) {
-                if($i > 0) {
-                    $postratings_ratingstext[$i] = sprintf(esc_html__('%s Stars', 'wp-postratings'), number_format_i18n($i+1));
-                } else {
-                    $postratings_ratingstext[$i] = sprintf(esc_html__('%s Star', 'wp-postratings'), number_format_i18n($i+1));
-                }
+                $postratings_ratingstext[$i] = esc_html__(sprintf(_n('%s Star', '%s Stars', $i, 'wp-postratings'), number_format_i18n($i+1)));
                 $postratings_ratingsvalue[$i] = $i+1;
             }
         }
@@ -637,19 +640,27 @@ function manage_ratings()
             </thead>
             <tbody>
                 <?php
+                     $image_start = $image_end = '';
+        if(is_rtl() && file_exists($postratings_path.'/'.$postratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT)) {
+            $image_start = '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT.'" alt="rating_start-rtl.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
+        } elseif(file_exists($postratings_path.'/'.$postratings_image.'/rating_start.'.RATINGS_IMG_EXT)) {
+            $image_start = '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_start.'.RATINGS_IMG_EXT.'" alt="rating_start.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
+        }
+
+        if(is_rtl() && file_exists($postratings_path.'/'.$postratings_image.'/rating_end-rtl.'.RATINGS_IMG_EXT)) {
+            $image_end = '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_end-rtl.'.RATINGS_IMG_EXT.'" alt="rating_end-rtl.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
+        } elseif(file_exists($postratings_path.'/'.$postratings_image.'/rating_end.'.RATINGS_IMG_EXT)) {
+            $image_end = '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_end.'.RATINGS_IMG_EXT.'" alt="rating_end.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
+        }
+
                     for($i = 1; $i <= $postratings_max; $i++) {
                         $postratings_text = stripslashes($postratings_ratingstext[$i-1]);
                         $postratings_value = $postratings_ratingsvalue[$i-1];
                         if($postratings_value > 0) {
                             $postratings_value = '+'.$postratings_value;
                         }
-                        echo '<tr>'."\n";
-                        echo '<td>'."\n";
-                        if(is_rtl() && file_exists($postratings_path.'/'.$postratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT)) {
-                            echo '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT.'" alt="rating_start-rtl.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
-                        } elseif(file_exists($postratings_path.'/'.$postratings_image.'/rating_start.'.RATINGS_IMG_EXT)) {
-                            echo '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_start.'.RATINGS_IMG_EXT.'" alt="rating_start.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
-                        }
+                        echo "<tr>\n<td>\n";
+                        echo $image_start;
                         if($postratings_customrating) {
                             if($postratings_max == 2) {
                                 echo '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_'.$i.'_on.'.RATINGS_IMG_EXT.'" alt="rating_'.$i.'_on.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
@@ -663,19 +674,13 @@ function manage_ratings()
                                 echo '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_on.'.RATINGS_IMG_EXT.'" alt="rating_on.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
                             }
                         }
-                        if(is_rtl() && file_exists($postratings_path.'/'.$postratings_image.'/rating_end-rtl.'.RATINGS_IMG_EXT)) {
-                            echo '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_end-rtl.'.RATINGS_IMG_EXT.'" alt="rating_end-rtl.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
-                        } elseif(file_exists($postratings_path.'/'.$postratings_image.'/rating_end.'.RATINGS_IMG_EXT)) {
-                            echo '<img src="'.$postratings_url.'/'.$postratings_image.'/rating_end.'.RATINGS_IMG_EXT.'" alt="rating_end.'.RATINGS_IMG_EXT.'" class="post-ratings-image" />';
-                        }
-                        echo '</td>'."\n";
-                        echo '<td>'."\n";
-                        echo '<input type="text" id="postratings_ratingstext_'.$i.'" name="postratings_ratingstext[]" value="'.$postratings_text.'" size="20" maxlength="50" />'."\n";
-                        echo '</td>'."\n";
-                        echo '<td>'."\n";
-                        echo '<input type="text" id="postratings_ratingsvalue_'.$i.'" name="postratings_ratingsvalue[]" value="'.$postratings_value.'" size="2" maxlength="2" />'."\n";
-                        echo '</td>'."\n";
-                        echo '</tr>'."\n";
+                        echo $image_end;
+                        echo <<<EOF
+</td>
+<td> <input type="text" id="postratings_ratingstext_{$i}" name="postratings_ratingstext[]" value="{$postratings_text}" size="20" maxlength="50" />  </td>
+<td> <input type="text" id="postratings_ratingsvalue_{$i}" name="postratings_ratingsvalue[]" value="{$postratings_value}" size="2" maxlength="2" /> </td>
+</tr>
+EOF;
                     }
                 ?>
             </tbody>
@@ -809,29 +814,22 @@ function postratings_page_admin_general_stats($content) {
 
 ### Function: Add WP-PostRatings Top Most/Highest Stats To WP-Stats Page Options
 function postratings_page_admin_most_stats($content) {
+    $content = array();
     $stats_display = get_option('stats_display');
     $stats_mostlimit = intval(get_option('stats_mostlimit'));
-    if($stats_display['rated_highest_post'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_post" value="rated_highest_post" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_highest_post">'.esc_html(sprintf(_n('%s Highest Rated Post', '%s Highest Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
-    } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_post" value="rated_highest_post" />&nbsp;&nbsp;<label for="wpstats_rated_highest_post">'.esc_html(sprintf(_n('%s Highest Rated Post', '%s Highest Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
+
+    foreach(array('rated_highest_post' => _n('%s Highest Rated Post', '%s Highest Rated Posts', $stats_mostlimit, 'wp-postratings'),
+                  'rated_highest_page' => _n('%s Highest Rated Page', '%s Highest Rated Pages', $stats_mostlimit, 'wp-postratings'),
+                  'rated_most_post'    => _n('%s Most Rated Post',    '%s Most Rated Posts', $stats_mostlimit, 'wp-postratings'),
+                  'rated_most_page'    => _n('%s Most Rated Page',    '%s Most Rated Pages', $stats_mostlimit, 'wp-postratings')) as $k => $v) {
+        if($stats_display[$k] == 1) {
+            $content[] = '<input type="checkbox" name="stats_display[]" id="wpstats_' .$k . '" value="' . $k . '" ' . ($stats_display['rated_highest_post'] == 1 ? ' checked="checked"' : '') . ' />'
+                       . '&nbsp;&nbsp;'
+                       . ' <label for="wpstats_rated_highest_post">'.esc_html(sprintf($v, number_format_i18n($stats_mostlimit))).'</label><br/>'."\n";
+        }
     }
-    if($stats_display['rated_highest_page'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_page" value="rated_highest_page" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_highest_page">'.esc_html(sprintf(_n('%s Highest Rated Page', '%s Highest Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
-    } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_highest_page" value="rated_highest_page" />&nbsp;&nbsp;<label for="wpstats_rated_highest_page">'.esc_html(sprintf(_n('%s Highest Rated Page', '%s Highest Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
-    }
-    if($stats_display['rated_most_post'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_post" value="rated_most_post" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_most_post">'.esc_html(sprintf(_n('%s Most Rated Post', '%s Most Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
-    } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_post" value="rated_most_post" />&nbsp;&nbsp;<label for="wpstats_rated_most_post">'.esc_html(sprintf(_n('%s Most Rated Post', '%s Most Rated Posts', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
-    }
-    if($stats_display['rated_most_page'] == 1) {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_page" value="rated_most_page" checked="checked" />&nbsp;&nbsp;<label for="wpstats_rated_most_page">'.esc_html(sprintf(_n('%s Most Rated Page', '%s Most Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
-    } else {
-        $content .= '<input type="checkbox" name="stats_display[]" id="wpstats_rated_most_page" value="rated_most_page" />&nbsp;&nbsp;<label for="wpstats_rated_most_page">'.esc_html(sprintf(_n('%s Most Rated Page', '%s Most Rated Pages', $stats_mostlimit, 'wp-postratings'), number_format_i18n($stats_mostlimit))).'</label><br />'."\n";
-    }
-    return $content;
+
+    return implode('', $content);
 }
 
 
@@ -929,66 +927,77 @@ function get_ratings_images($ratings_custom, $ratings_max, $post_rating, $rating
 }
 
 
+// $custom: true|false
+// $type: one of [on, off, half, half-rtl]
+function get_rating_image_url($ratings_image, $type, $i = null /* if custom */) {
+  if ($i) {
+    return plugins_url(sprintf("/wp-postratings/images/%s/rating_%d_%s.%s", $ratings_image, $i, $type, RATINGS_IMG_EXT));
+  } else {
+    return plugins_url(sprintf("/wp-postratings/images/%s/rating_%s.%s", $ratings_image, $type, RATINGS_IMG_EXT));
+  }
+}
+
 ### Function: Gets HTML of rating images for voting
 function get_ratings_images_vote($post_id, $ratings_custom, $ratings_max, $post_rating, $ratings_image, $image_alt, $insert_half, $ratings_texts) {
-    $ratings_images = '';
+    $ratings_images = array();
+
     $ratings_image = esc_attr( $ratings_image );
     if(is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT)) {
-        $ratings_images .= '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
+        $ratings_images[] = '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_start-rtl.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
     } elseif(file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_start.'.RATINGS_IMG_EXT)) {
-        $ratings_images .= '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_start.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
+        $ratings_images[] = '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_start.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
     }
-    if($ratings_custom) {
-        for($i=1; $i <= $ratings_max; $i++) {
-            if (is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_'.$i.'half-rtl.'.RATINGS_IMG_EXT)) {
-                $use_half_rtl = 1;
-            } else {
-                $use_half_rtl = 0;
-            }
-            $ratings_text = esc_attr( stripslashes( $ratings_texts[$i-1] ) );
-            $ratings_text_js = esc_js( $ratings_text );
-            $image_alt = apply_filters( 'wp_postratings_ratings_image_alt', $ratings_text );
-            if($i <= $post_rating) {
-                $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_'.$i.'_on.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-            } elseif($i == $insert_half) {
-                if ($use_half_rtl) {
-                    $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_'.$i.'_half-rtl.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-                } else {
-                    $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_'.$i.'_half.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-                }
-            } else {
-                $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_'.$i.'_off.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-            }
-        }
+
+    if (is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_'.$i.'half-rtl.'.RATINGS_IMG_EXT)) {
+      $use_custom_half_rtl = 1;
     } else {
-        if (is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_half-rtl.'.RATINGS_IMG_EXT)) {
-            $use_half_rtl = 1;
-        } else {
-            $use_half_rtl = 0;
-        }
-        for($i=1; $i <= $ratings_max; $i++) {
-            $ratings_text = esc_attr( stripslashes( $ratings_texts[$i-1] ) );
-            $ratings_text_js = esc_js( $ratings_text );
-            $image_alt = apply_filters( 'wp_postratings_ratings_image_alt', $ratings_text );
-            if($i <= $post_rating) {
-                $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_on.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-            } elseif($i == $insert_half) {
-                if ($use_half_rtl) {
-                    $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_half-rtl.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-                } else {
-                    $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_half.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-                }
-            } else {
-                $ratings_images .= '<img id="rating_'.$post_id.'_'.$i.'" src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_off.'.RATINGS_IMG_EXT).'" alt="'.$image_alt.'" title="'.$image_alt.'" onmouseover="current_rating('.$post_id.', '.$i.', \''.$ratings_text_js.'\');" onmouseout="ratings_off('.$post_rating.', '.$insert_half.', '.$use_half_rtl.');" onclick="rate_post();" onkeypress="rate_post();" style="cursor: pointer; border: 0px;" />';
-            }
-        }
+      $use_custom_half_rtl = 0;
     }
+    if (is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_half-rtl.'.RATINGS_IMG_EXT)) {
+      $use_half_rtl = 1;
+    } else {
+      $use_half_rtl = 0;
+    }
+
+
+    for($i=1; $i <= $ratings_max; $i++) {
+      $ratings_text = esc_attr( stripslashes( $ratings_texts[$i-1] ) ) ;
+      $image_alt = esc_attr( apply_filters( 'wp_postratings_ratings_image_alt', $ratings_text ) );
+
+      $rating_attr = array(
+        'id' => "rating_" . $post_id . "_" . $i,
+        'alt' => $image_alt,
+        'title' => $image_alt,
+        'onmouseover' => esc_js( sprintf( "current_rating(%d, %d, \"%s\");", $post_id, $i, $ratings_text) ),
+        'onclick' => sprintf( "rate_post(%d, %d);", $post_id, $i),
+        'onkeypress' => sprintf( "rate_post(%d, %d);", $post_id, $i),
+        'style' => "cursor:pointer; border:0px;"
+      );
+
+      if($ratings_custom) {
+        $rating_attr += array(
+          'src' => get_rating_image_url($ratings_image, $i <= $post_rating ? 'on' : $i == $insert_half ? $use_custom_half_rtl ? 'half-rtl' : 'half' : 'off', $i),
+          'onmouseout' => sprintf("ratings_off(%d, %d, %d, %d);", $post_id, $post_rating, $insert_half, $use_custom_half_rtl),
+        );
+      } else {
+        $rating_attr += array(
+          'src' => get_rating_image_url($ratings_image, $i <= $post_rating ? 'on' : $i == $insert_half ? $use_half_rtl ? 'half-rtl' : 'half' : 'off', NULL),
+          'onmouseout' => sprintf("ratings_off(%d, %d, %d, %d);", $post_id, $post_rating, $insert_half, $use_half_rtl),
+        );
+      }
+
+      $ratings_images[] = '<img ' . implode(' ', array_map(function($k, $v) { return sprintf('%s="%s"',$k,$v); }, array_keys($rating_attr), $rating_attr)) . ' />';
+    }
+
+
     if(is_rtl() && file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_end-rtl.'.RATINGS_IMG_EXT)) {
-        $ratings_images .= '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_end-rtl.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
-    } elseif(file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_end.'.RATINGS_IMG_EXT)) {
-        $ratings_images .= '<img src="'.plugins_url('/wp-postratings/images/'.$ratings_image.'/rating_end.'.RATINGS_IMG_EXT).'" alt="" class="post-ratings-image" />';
+      $ratings_images[] = '<img src="' . get_rating_image_url($ratings_image, 'end', NULL) . '" alt="" class="post-ratings-image" />';
     }
-    return $ratings_images;
+    elseif(file_exists(WP_PLUGIN_DIR.'/wp-postratings/images/'.$ratings_image.'/rating_end.'.RATINGS_IMG_EXT)) {
+      $ratings_images[] = '<img src="' . get_rating_image_url($ratings_image, 'end', NULL) . '" alt="" class="post-ratings-image" />';
+    }
+
+    return implode('', $ratings_images);
 }
 
 
@@ -1111,13 +1120,14 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
         $post_ratings_images = apply_filters( 'wp_postratings_ratings_images_vote', $get_ratings_images_vote, $post_id, $post_ratings, $ratings_max );
         $value = str_replace( "%RATINGS_IMAGES_VOTE%", $post_ratings_images, $value );
     }
-    $value = str_replace("%RATINGS_ALT_TEXT%", $post_ratings_alt_text, $value);
-    $value = str_replace("%RATINGS_TEXT%", $post_ratings_text, $value);
-    $value = str_replace("%RATINGS_MAX%", number_format_i18n($ratings_max), $value);
-    $value = str_replace("%RATINGS_SCORE%", $post_ratings_score, $value);
-    $value = str_replace("%RATINGS_AVERAGE%", number_format_i18n($post_ratings_average, 2), $value);
-    $value = str_replace("%RATINGS_PERCENTAGE%", number_format_i18n($post_ratings_percentage, 2), $value);
-    $value = str_replace("%RATINGS_USERS%", number_format_i18n($post_ratings_users), $value);
+
+    $search1 = array("%RATINGS_ALT_TEXT%",   "%RATINGS_TEXT%",   "%RATINGS_MAX%",                  "%RATINGS_SCORE%");
+    $replac1 = array($post_ratings_alt_text, $post_ratings_text, number_format_i18n($ratings_max), $post_ratings_score);
+    $value = str_replace($search1, $replac1, $value);
+
+    $search2 = array("%RATINGS_AVERAGE%",                          "%RATINGS_PERCENTAGE%",                          "%RATINGS_USERS%");
+    $replac2 = array(number_format_i18n($post_ratings_average, 2), number_format_i18n($post_ratings_percentage, 2), number_format_i18n($post_ratings_users));
+    $value = str_replace($search2, $replac2, $value);
 
     // Post Template Variables
     $post_link = get_permalink($post_data);
@@ -1125,32 +1135,29 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
     if ($max_post_title_chars > 0) {
         $post_title = snippet_text($post_title, $max_post_title_chars);
     }
-    $value = str_replace("%POST_ID%", $post_id, $value);
-    $value = str_replace("%POST_TITLE%", $post_title, $value);
-    $value = str_replace("%POST_URL%", $post_link, $value);
+    $value = str_replace(array("%POST_ID%", "%POST_TITLE%", "%POST_URL%"),
+                         array($post_id,    $post_title,    $post_link),
+                         $value);
 
-    if (strpos($template, '%POST_EXCERPT%') !== false) {
+    if (preg_match('/%POST_(EXCERPT|CONTENT|THUMBNAIL)%/', $template)) {
         if (get_the_ID() != $post_id) {
             $post = &get_post($post_id);
         }
-        $post_excerpt = ratings_post_excerpt($post_id, $post->post_excerpt, $post->post_content, $post->post_password);
-        $value = str_replace("%POST_EXCERPT%", $post_excerpt, $value);
-    }
-    if (strpos($template, '%POST_CONTENT%') !== false) {
-        if (get_the_ID() != $post_id) {
-            $post = &get_post($post_id);
+
+        if (strpos($template, '%POST_EXCERPT%') !== false) {
+            $post_excerpt = ratings_post_excerpt($post_id, $post->post_excerpt, $post->post_content, $post->post_password);
+            $value = str_replace("%POST_EXCERPT%", $post_excerpt, $value);
         }
-        $value = str_replace("%POST_CONTENT%", get_the_content(), $value);
-    }
-    if (strpos($template, '%POST_THUMBNAIL%') !== false) {
-        if (get_the_ID() != $post_id) {
-            $post = &get_post($post_id);
+        if (strpos($template, '%POST_CONTENT%') !== false) {
+            $value = str_replace("%POST_CONTENT%", get_the_content(), $value);
         }
-        $value = str_replace( '%POST_THUMBNAIL%', get_the_post_thumbnail( $post, 'thumbnail' ), $value );
+        if (strpos($template, '%POST_THUMBNAIL%') !== false) {
+            $value = str_replace( '%POST_THUMBNAIL%', get_the_post_thumbnail( $post, 'thumbnail' ), $value );
+        }
     }
 
     // Google Rich Snippet
-	$google_structured_data = '';
+    $google_structured_data = '';
     $ratings_options['richsnippet'] = isset( $ratings_options['richsnippet'] ) ? $ratings_options['richsnippet'] : 1;
     if( $ratings_options['richsnippet'] && is_singular() && $is_main_loop ) {
         $itemtype = apply_filters( 'wp_postratings_schema_itemtype', 'itemscope itemtype="http://schema.org/Article"' );
@@ -1158,24 +1165,25 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
         if( empty( $post_excerpt ) ) {
             $post_excerpt = ratings_post_excerpt( $post_id, $post->post_excerpt, $post->post_content, $post->post_password );
         }
-        $post_meta = '<meta itemprop="headline" content="' . esc_attr( $post_title ) . '" />';
-        $post_meta .= '<meta itemprop="description" content="' . wp_kses( $post_excerpt, array() ) . '" />';
-        $post_meta .= '<meta itemprop="datePublished" content="' . mysql2date( 'c', $post->post_date, false ) . '" />';
-        $post_meta .= '<meta itemprop="dateModified" content="' . mysql2date( 'c', $post->post_modified, false ) . '" />';
-        $post_meta .= '<meta itemprop="url" content="' . $post_link . '" />';
-        $post_meta .= '<meta itemprop="author" content="' . get_the_author() . '" />';
-        $post_meta .= '<meta itemprop="mainEntityOfPage" content="' . get_permalink() . '" />';
+        $post_meta = '<meta itemprop="headline" content="' . esc_attr( $post_title ) . '" />'
+                   . '<meta itemprop="description" content="' . wp_kses( $post_excerpt, array() ) . '" />'
+                   . '<meta itemprop="datePublished" content="' . mysql2date( 'c', $post->post_date, false ) . '" />'
+                   . '<meta itemprop="dateModified" content="' . mysql2date( 'c', $post->post_modified, false ) . '" />'
+                   . '<meta itemprop="url" content="' . $post_link . '" />'
+                   . '<meta itemprop="author" content="' . get_the_author() . '" />'
+                   . '<meta itemprop="mainEntityOfPage" content="' . get_permalink() . '" />';
+
         // Image
-        if( has_post_thumbnail() ) {
-            $thumbnail = wp_get_attachment_image_src( get_post_thumbnail_id( null ) );
-            if( ! empty( $thumbnail ) ) {
-                $post_meta .= '<div style="display: none;" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">';
-                $post_meta .= '<meta itemprop="url" content="' . $thumbnail[0] . '" />';
-                $post_meta .= '<meta itemprop="width" content="' . $thumbnail[1] . '" />';
-                $post_meta .= '<meta itemprop="height" content="' . $thumbnail[2] . '" />';
-                $post_meta .= '</div>';
-            }
+        if( has_post_thumbnail() && ( $thumbnail = wp_get_attachment_image_src( get_post_thumbnail_id( null ) ) ) ) {
+                $post_meta .= <<<EOF
+<div style="display: none;" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+<meta itemprop="url" content="{$thumbnail[0]}" />
+<meta itemprop="width" content="{$thumbnail[1]}" />
+<meta itemprop="height" content="{$thumbnail[2]}" />
+</div>
+EOF;
         }
+
         // Publisher
         $site_logo = '';
         if ( function_exists( 'the_custom_logo' ) ) {
@@ -1185,7 +1193,7 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
                 $site_logo = $custom_logo[0];
             }
         }
-        if( empty( $site_logo ) ) {
+        if( ! $site_logo ) {
             if( has_header_image() ) {
                 $header_image = get_header_image();
                 if( ! empty( $header_image ) ) {
@@ -1193,22 +1201,28 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
                 }
             }
         }
+
         $site_logo = apply_filters( 'wp_postratings_site_logo', $site_logo );
-        $post_meta .= '<div style="display: none;" itemprop="publisher" itemscope itemtype="https://schema.org/Organization">';
-        $post_meta .= '<meta itemprop="name" content="' . get_bloginfo( 'name' ) . '" />';
-        $post_meta .= '<div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">';
-        $post_meta .= '<meta itemprop="url" content="' . $site_logo . '" />';
-        $post_meta .= '</div>';
-        $post_meta .= '</div>';
+        $site_name = get_bloginfo( 'name' );
+        $post_meta .= <<<EOF
+<div style="display: none;" itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+<meta itemprop="name" content="{$site_name}" />
+<div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+<meta itemprop="url" content="{$site_logo}" />
+</div>
+</div>
+EOF;
 
         $ratings_meta = '';
         if( $post_ratings_average > 0 ) {
-            $ratings_meta .= '<div style="display: none;" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">';
-            $ratings_meta .= '<meta itemprop="bestRating" content="' . $ratings_max . '" />';
-            $ratings_meta .= '<meta itemprop="worstRating" content="1" />';
-            $ratings_meta .= '<meta itemprop="ratingValue" content="' . $post_ratings_average . '" />';
-            $ratings_meta .= '<meta itemprop="ratingCount" content="' . $post_ratings_users . '" />';
-            $ratings_meta .= '</div>';
+            $ratings_meta = <<<EOF
+'<div style="display: none;" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
+<meta itemprop="bestRating" content="{$ratings_max}" />
+<meta itemprop="worstRating" content="1" />
+<meta itemprop="ratingValue" content="{$post_ratings_average}" />
+<meta itemprop="ratingCount" content="{$post_ratings_users}" />
+</div>
+EOF;
         }
 
         $google_structured_data =  apply_filters( 'wp_postratings_google_structured_data', ( empty( $itemtype ) ? $ratings_meta : ( $post_meta . $ratings_meta ) ) );

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -968,7 +968,10 @@ function get_ratings_images_vote($post_id, $ratings_custom, $ratings_max, $post_
         'id' => "rating_" . $post_id . "_" . $i,
         'alt' => $image_alt,
         'title' => $image_alt,
-        'onmouseover' => esc_js( sprintf( "current_rating(%d, %d, \"%s\");", $post_id, $i, $ratings_text) ),
+        'data-id' => $post_id,
+        'data-votes' => $i,
+        'data-ratings-text' => $ratings_text,
+        'onmouseover' => esc_js( sprintf( "current_rating(%d, %d);", $post_id, $i) ),
         'onclick' => sprintf( "rate_post(%d, %d);", $post_id, $i),
         'onkeypress' => sprintf( "rate_post(%d, %d);", $post_id, $i),
         'style' => "cursor:pointer; border:0px;"


### PR DESCRIPTION
* avoid code/routine duplication
  especially for postratings_page_admin_most_stats() and get_ratings_images_vote()
* use ternary operator where it improve readability
* use here-doc where possible
* move wp_localize_script() where the_rating() actually display voting form
  and move part of its logic client-side => code simplification
* use document.getElementById() where it makes things simpler
  and alias jQuery to $j
* move some "static" file_exists() outside of loops and use a cleaner
  way to declare/implode() complex markup
* avoid double-escaping, let this task to wpdb() + use wpdb->insert()


this is the first part needed to adapt the code further deeper changes.
please review & merge ASAP ;)