### PR TITLE
Adds an "admin column" option to post ratings setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Adds an AJAX rating system for your WordPress site's content.
 I spent most of my free time creating, updating, maintaining and supporting these plugins, if you really love my plugins and could spare me a couple of bucks, I will really appreciate it. If not feel free to use it without any obligations.
 
 ## Changelog
+### Version 1.85
+* NEW: Added 'postratings_admincolumn' option which toggles the display of ratings in the admin posts interface.
+
 ### Version 1.84.1
 * NEW: New wp_postratings_google_structured_data filter to filter Google Structured Data.
 * FIXED: unnamed-file.numbers due to sanitize_file_name().

--- a/includes/postratings-activation.php
+++ b/includes/postratings-activation.php
@@ -80,6 +80,8 @@ function ratings_activate() {
 	// Database Upgrade For WP-PostRatings 1.50
 	delete_option('widget_ratings_highest_rated');
 	delete_option('widget_ratings_most_rated');
+    // Database Upgrade For WP-PostRatings 1.85
+    add_option('postratings_admincolumn', '1' );
 
 	// Index
 	$index = $wpdb->get_results( "SHOW INDEX FROM $wpdb->ratings;" );

--- a/includes/postratings-admin.php
+++ b/includes/postratings-admin.php
@@ -29,20 +29,22 @@ class WPPostRatingsAdmin {
 	public function __construct() {
 
 		// Administration Menu
-		add_action( 'admin_menu', array( $this, 'ratings_menu' ) );
+        $show_admin_column = intval(get_option('postratings_admincolumn'));
+        add_action( 'admin_menu', array( $this, 'ratings_menu' ) );
 
-		// Add rating column to the admin
-		add_filter( 'manage_posts_columns', array( $this, 'postrating_admin_column_title' ) );
-		add_filter( 'manage_pages_columns', array( $this, 'postrating_admin_column_title' ) );
+        if($show_admin_column === 1){
+            // Add rating column to the admin
+            add_filter( 'manage_posts_columns', array( $this, 'postrating_admin_column_title' ) );
+            add_filter( 'manage_pages_columns', array( $this, 'postrating_admin_column_title' ) );
 
-		// Fill rating column in the admin
-		add_action( 'manage_posts_custom_column', array( $this, 'postrating_admin_column_content' ) );
-		add_action( 'manage_pages_custom_column', array( $this, 'postrating_admin_column_content' ) );
+            // Fill rating column in the admin
+            add_action( 'manage_posts_custom_column', array( $this, 'postrating_admin_column_content' ) );
+            add_action( 'manage_pages_custom_column', array( $this, 'postrating_admin_column_content' ) );
 
-		// Sort rating column in the admin
-		add_filter( 'manage_edit-post_sortable_columns', array( $this, 'postrating_admin_column_sort' ) );
-		add_filter( 'manage_edit-page_sortable_columns', array( $this, 'postrating_admin_column_sort' ) );
-
+            // Sort rating column in the admin
+            add_filter( 'manage_edit-post_sortable_columns', array( $this, 'postrating_admin_column_sort' ) );
+            add_filter( 'manage_edit-page_sortable_columns', array( $this, 'postrating_admin_column_sort' ) );
+        }
 	}
 
 	/*

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -61,6 +61,7 @@ if ( isset( $_POST['Submit'] ) ) {
     $postratings_ajax_style = array('loading' => intval($_POST['postratings_ajax_style_loading']), 'fading' => intval($_POST['postratings_ajax_style_fading']));
     $postratings_logging_method = intval($_POST['postratings_logging_method']);
     $postratings_allowtorate = intval($_POST['postratings_allowtorate']);
+    $postratings_admincolumn = intval($_POST['postratings_admincolumn']);
     $update_ratings_queries = array();
     $update_ratings_text = array();
     $postratings_options = array('richsnippet' => $postratings_richsnippet);
@@ -78,6 +79,7 @@ if ( isset( $_POST['Submit'] ) ) {
     $update_ratings_queries[] = update_option('postratings_ajax_style', $postratings_ajax_style);
     $update_ratings_queries[] = update_option('postratings_logging_method', $postratings_logging_method);
     $update_ratings_queries[] = update_option('postratings_allowtorate', $postratings_allowtorate);
+    $update_ratings_queries[] = update_option('postratings_admincolumn', $postratings_admincolumn);
     $update_ratings_queries[] = update_option('postratings_options', $postratings_options);
     $update_ratings_text[] = __('Custom Rating', 'wp-postratings');
     $update_ratings_text[] = __('Ratings Template Vote', 'wp-postratings');
@@ -93,6 +95,7 @@ if ( isset( $_POST['Submit'] ) ) {
     $update_ratings_text[] = __('Ratings AJAX Style', 'wp-postratings');
     $update_ratings_text[] = __('Logging Method', 'wp-postratings');
     $update_ratings_text[] = __('Allow To Vote Option', 'wp-postratings');
+    $update_ratings_text[] = __('Admin Column', 'wp-postratings');
     $update_ratings_text[] = __('Ratings Settings', 'wp-postratings');
     $i = 0;
     $text = '';
@@ -412,6 +415,18 @@ $postratings_image = get_option('postratings_image');
                         <option value="2"<?php selected('2', get_option('postratings_logging_method')); ?>><?php esc_html_e('Logged By IP', 'wp-postratings'); ?></option>
                         <option value="3"<?php selected('3', get_option('postratings_logging_method')); ?>><?php esc_html_e('Logged By Cookie And IP', 'wp-postratings'); ?></option>
                         <option value="4"<?php selected('4', get_option('postratings_logging_method')); ?>><?php esc_html_e('Logged By Username', 'wp-postratings'); ?></option>
+                    </select>
+                </td>
+            </tr>
+        </table>
+        <h2><?php esc_html_e('Admin Column', 'wp-postratings'); ?></h2>
+        <table class="form-table">
+            <tr>
+                <th scope="row" valign="top"><?php esc_html_e('Show Ratings as an admin column?', 'wp-postratings'); ?></th>
+                <td>
+                    <select name="postratings_admincolumn" size="1">
+                        <option value="1"<?php selected('1', get_option('postratings_admincolumn')); ?>><?php esc_html_e('Yes', 'wp-postratings'); ?></option>
+                        <option value="0"<?php selected('0', get_option('postratings_admincolumn')); ?>><?php esc_html_e('No', 'wp-postratings'); ?></option>
                     </select>
                 </td>
             </tr>

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,6 +13,7 @@ $option_names = array(
 	, 'postratings_template_none'
 	, 'postratings_logging_method'
 	, 'postratings_allowtorate'
+    , 'postratings_admincolumn'
 	, 'postratings_ratingstext'
 	, 'postratings_template_highestrated'
 	, 'postratings_ajax_style'

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -41,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin version
  * Set wp-postratings plugin version.
  */
-define( 'WP_POSTRATINGS_VERSION', 1.84 );
+define( 'WP_POSTRATINGS_VERSION', 1.85 );
 
 /**
  * Rating logs table name


### PR DESCRIPTION
Greetings,

We're planning to use this fantastic plugin for an upcoming event where users can vote on a small portion of our posts. But since we have so many content creators and post types, we didn't want the "Ratings" column to show up for every post (i.e., mass email reminders and confused users...)

This adds a setting "Show Ratings as an admin column?" (`postratings_admincolumn`) that allows users to turn off that column. By default, it is set to "Yes" (`1`), so it doesn't change any base functionality.

FYI - I updated the changelog, but I'm not sure if this warranted a bump from 1.84 to 1.85. Wanted to let you know if you wish to change that information.

Cheers!