### PR TITLE
Custom vote text (singular and plural)

### DIFF
--- a/includes/postratings-activation.php
+++ b/includes/postratings-activation.php
@@ -81,6 +81,9 @@ function ratings_activate() {
 	delete_option('widget_ratings_highest_rated');
 	delete_option('widget_ratings_most_rated');
 
+	add_option('postratings_vote_text_singular', 'Vote' );
+	add_option('postratings_vote_text_plural', 'Votes' );
+
 	// Index
 	$index = $wpdb->get_results( "SHOW INDEX FROM $wpdb->ratings;" );
 	$key_name = array();

--- a/includes/postratings-activation.php
+++ b/includes/postratings-activation.php
@@ -58,8 +58,8 @@ function ratings_activate() {
 	// Add In Options (4 Records)
 	add_option('postratings_image', 'stars' );
 	add_option('postratings_max', '5' );
-	add_option('postratings_template_vote', '%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> '.__('votes', 'wp-postratings').__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': <strong>%RATINGS_AVERAGE%</strong> '.__('out of', 'wp-postratings').' %RATINGS_MAX%)<br />%RATINGS_TEXT%' );
-	add_option('postratings_template_text', '%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> '.__('votes', 'wp-postratings').__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': <strong>%RATINGS_AVERAGE%</strong> '.__('out of', 'wp-postratings').' %RATINGS_MAX%'.__(',', 'wp-postratings').' <strong>'.__('rated', 'wp-postratings').'</strong></em>)' );
+	add_option('postratings_template_vote', '%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%'.__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': <strong>%RATINGS_AVERAGE%</strong> '.__('out of', 'wp-postratings').' %RATINGS_MAX%)<br />%RATINGS_TEXT%' );
+	add_option('postratings_template_text', '%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%'.__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': <strong>%RATINGS_AVERAGE%</strong> '.__('out of', 'wp-postratings').' %RATINGS_MAX%'.__(',', 'wp-postratings').' <strong>'.__('rated', 'wp-postratings').'</strong></em>)' );
 	add_option('postratings_template_none', '%RATINGS_IMAGES_VOTE% ('.__('No Ratings Yet', 'wp-postratings').')<br />%RATINGS_TEXT%' );
 	// Database Upgrade For WP-PostRatings 1.02
 	add_option('postratings_logging_method', '3' );
@@ -74,15 +74,15 @@ function ratings_activate() {
 	// Database Upgrade For WP-PostRatings 1.20
 	add_option('postratings_ratingsvalue', array(1,2,3,4,5) );
 	add_option('postratings_customrating', 0 );
-	add_option('postratings_template_permission', '%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> '.__('votes', 'wp-postratings').__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': <strong>%RATINGS_AVERAGE%</strong> '.__('out of', 'wp-postratings').' %RATINGS_MAX%</em>)<br /><em>'.__('You need to be a registered member to rate this.', 'wp-postratings').'</em>' );
+	add_option('postratings_template_permission', '%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%'.__(',', 'wp-postratings').' '.__('average', 'wp-postratings').': <strong>%RATINGS_AVERAGE%</strong> '.__('out of', 'wp-postratings').' %RATINGS_MAX%</em>)<br /><em>'.__('You need to be a registered member to rate this.', 'wp-postratings').'</em>' );
 	// Database Upgrade For WP-PostRatings 1.30
-	add_option('postratings_template_mostrated', '<li><a href="%POST_URL%"  title="%POST_TITLE%">%POST_TITLE%</a> - %RATINGS_USERS% '.__('votes', 'wp-postratings').'</li>' );
+	add_option('postratings_template_mostrated', '<li><a href="%POST_URL%"  title="%POST_TITLE%">%POST_TITLE%</a> - %RATINGS_USERS% %RATINGS_VOTE_TEXT%'.'</li>' );
 	// Database Upgrade For WP-PostRatings 1.50
 	delete_option('widget_ratings_highest_rated');
 	delete_option('widget_ratings_most_rated');
 
-	add_option('postratings_vote_text_singular', 'Vote' );
-	add_option('postratings_vote_text_plural', 'Votes' );
+	add_option('postratings_vote_text_singular', 'vote' );
+	add_option('postratings_vote_text_plural', 'votes' );
 
 	// Index
 	$index = $wpdb->get_results( "SHOW INDEX FROM $wpdb->ratings;" );

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -45,6 +45,8 @@ if ( isset( $_POST['Submit'] ) ) {
     $postratings_richsnippet = intval($_POST['postratings_richsnippet']);
     $postratings_ratingstext_array = $_POST['postratings_ratingstext'];
     $postratings_ratingstext = array();
+    $postratings_vote_text_singular = sanitize_text_field(trim($_POST['postratings_vote_text_singular']));
+    $postratings_vote_text_plural = sanitize_text_field(trim($_POST['postratings_vote_text_plural']));
     if( ! empty( $postratings_ratingstext_array ) && is_array( $postratings_ratingstext_array ) ) {
         foreach( $postratings_ratingstext_array as $ratingstext ) {
             $postratings_ratingstext[] = wp_kses_post(trim( $ratingstext ));
@@ -79,6 +81,8 @@ if ( isset( $_POST['Submit'] ) ) {
     $update_ratings_queries[] = update_option('postratings_logging_method', $postratings_logging_method);
     $update_ratings_queries[] = update_option('postratings_allowtorate', $postratings_allowtorate);
     $update_ratings_queries[] = update_option('postratings_options', $postratings_options);
+    $update_ratings_queries[] = update_option('postratings_vote_text_singular', $postratings_vote_text_singular);
+    $update_ratings_queries[] = update_option('postratings_vote_text_plural', $postratings_vote_text_plural);
     $update_ratings_text[] = __('Custom Rating', 'wp-postratings');
     $update_ratings_text[] = __('Ratings Template Vote', 'wp-postratings');
     $update_ratings_text[] = __('Ratings Template Voted', 'wp-postratings');
@@ -94,6 +98,8 @@ if ( isset( $_POST['Submit'] ) ) {
     $update_ratings_text[] = __('Logging Method', 'wp-postratings');
     $update_ratings_text[] = __('Allow To Vote Option', 'wp-postratings');
     $update_ratings_text[] = __('Ratings Settings', 'wp-postratings');
+    $update_ratings_text[] = __('Custom vote text (singular)', 'wp-postratings');
+    $update_ratings_text[] = __('Custom vote text (plural)', 'wp-postratings');
     $i = 0;
     $text = '';
     foreach($update_ratings_queries as $update_ratings_query) {
@@ -363,6 +369,21 @@ $postratings_image = get_option('postratings_image');
                 </tbody>
             </table>
         </div>
+        <h2><?php esc_html_e('Custom vote text', 'wp-postratings'); ?></h2>
+        <table class="form-table">
+             <tr>
+                <th scope="row" valign="top"><?php esc_html_e('Vote text (singular):', 'wp-postratings'); ?></th>
+                <td>
+                    <input type="text" name="postratings_vote_text_singular" value="<?php echo esc_attr(stripslashes(get_option('postratings_vote_text_singular'))) ?>">                    
+                </td>
+            </tr>
+            <tr>
+                <th scope="row" valign="top"><?php esc_html_e('Vote text (plural):', 'wp-postratings'); ?></th>
+                <td>
+                    <input type="text" name="postratings_vote_text_plural" value="<?php echo esc_attr(stripslashes(get_option('postratings_vote_text_plural'))) ?>">                    
+                </td>
+            </tr>
+        </table>
         <?php $postratings_ajax_style = get_option('postratings_ajax_style'); ?>
         <h2><?php esc_html_e('Ratings AJAX Style', 'wp-postratings'); ?></h2>
         <table class="form-table">

--- a/postratings-options.php
+++ b/postratings-options.php
@@ -130,22 +130,22 @@ $postratings_image = get_option('postratings_image');
         var default_template;
         switch(template) {
             case "vote":
-                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%)<br />%RATINGS_TEXT%";
                 break;
             case "text":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
                 break;
             case "permission":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
                 break;
             case "none":
                 default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
                 break;
             case "highestrated":
-                default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?>)</li>";
+                default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> %RATINGS_USERS% %RATINGS_VOTE_TEXT%)</li>";
                 break;
             case "mostrated":
-                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
+                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% %RATINGS_VOTE_TEXT%</li>";
                 break;
         }
         if(print) {
@@ -158,13 +158,13 @@ $postratings_image = get_option('postratings_image');
         var default_template;
         switch(template) {
             case "vote":
-                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
+                default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
                 break;
             case "text":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
                 break;
             case "permission":
-                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+                default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
                 break;
             case "none":
                 default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
@@ -173,7 +173,7 @@ $postratings_image = get_option('postratings_image');
                 default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> %RATINGS_IMAGES% (%RATINGS_AVERAGE% <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)</li>";
                 break;
             case "mostrated":
-                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
+                default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% %RATINGS_VOTE_TEXT%</li>";
                 break;
         }
         if(print) {

--- a/postratings-templates.php
+++ b/postratings-templates.php
@@ -72,19 +72,19 @@ if ( isset( $_POST['Submit'] ) ) {
 		var default_template;
 		switch(template) {
 			case "vote":
-				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
+				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%)<br />%RATINGS_TEXT%";
 				break;
 			case "text":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
 				break;
 			case "permission":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_SCORE%</strong> <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
 				break;
 			case "none":
 				default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
 				break;
 			case "highestrated":
-				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?>)</li>";
+				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> %RATINGS_USERS% %RATINGS_VOTE_TEXT%)</li>";
 				break;
 			case "mostrated":
 				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% %RATINGS_VOTE_TEXT%</li>";

--- a/postratings-templates.php
+++ b/postratings-templates.php
@@ -87,7 +87,7 @@ if ( isset( $_POST['Submit'] ) ) {
 				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> (%RATINGS_SCORE% <?php esc_html_e('rating', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?>)</li>";
 				break;
 			case "mostrated":
-				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
+				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% %RATINGS_VOTE_TEXT%</li>";
 				break;
 		}
 		if(print) {
@@ -100,13 +100,13 @@ if ( isset( $_POST['Submit'] ) ) {
 		var default_template;
 		switch(template) {
 			case "vote":
-				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
+				default_template = "%RATINGS_IMAGES_VOTE% (<strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)<br />%RATINGS_TEXT%";
 				break;
 			case "text":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%<?php esc_html_e(',', 'wp-postratings'); ?> <strong><?php esc_html_e('rated', 'wp-postratings'); ?></strong></em>)";
 				break;
 			case "permission":
-				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> <?php esc_html_e('votes', 'wp-postratings'); ?><?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
+				default_template = "%RATINGS_IMAGES% (<em><strong>%RATINGS_USERS%</strong> %RATINGS_VOTE_TEXT%<?php esc_html_e(',', 'wp-postratings'); ?> <?php esc_html_e('average', 'wp-postratings'); ?>: <strong>%RATINGS_AVERAGE%</strong> <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%</em>)<br /><em><?php esc_html_e('You need to be a registered member to rate this.', 'wp-postratings'); ?></em>";
 				break;
 			case "none":
 				default_template = "%RATINGS_IMAGES_VOTE% (<?php esc_html_e('No Ratings Yet', 'wp-postratings'); ?>)<br />%RATINGS_TEXT%";
@@ -115,7 +115,7 @@ if ( isset( $_POST['Submit'] ) ) {
 				default_template = "<li><a href=\"%POST_URL%\" title=\"%POST_TITLE%\">%POST_TITLE%</a> %RATINGS_IMAGES% (%RATINGS_AVERAGE% <?php esc_html_e('out of', 'wp-postratings'); ?> %RATINGS_MAX%)</li>";
 				break;
 			case "mostrated":
-				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% <?php esc_html_e('votes', 'wp-postratings'); ?></li>";
+				default_template = "<li><a href=\"%POST_URL%\"  title=\"%POST_TITLE%\">%POST_TITLE%</a> - %RATINGS_USERS% %RATINGS_VOTE_TEXT%</li>";
 				break;
 		}
 		if(print) {
@@ -149,6 +149,9 @@ if ( isset( $_POST['Submit'] ) ) {
 				<td><strong>%RATINGS_SCORE%</strong> - <?php esc_html_e('Display the total score of the ratings', 'wp-postratings'); ?></td>
 				<td><strong>%RATINGS_TEXT%</strong> - <?php esc_html_e('Display the individual rating text. Eg: 1 Star, 2 Stars, etc', 'wp-postratings'); ?></td>
 			</tr>
+			<tr>
+				<td><strong>%RATINGS_VOTE_TEXT%</strong> - <?php esc_html_e('Display the \'votes\' text.', 'wp-postratings'); ?></td>
+			</tr>
 		</table>
 		<h2><?php esc_html_e('Ratings Templates', 'wp-postratings'); ?></h2>
 		<table class="form-table">
@@ -163,6 +166,7 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %RATINGS_PERCENTAGE%</p>
+					<p style="margin: 2px 0">- %RATINGS_VOTE_TEXT%</p>
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('vote', true);" class="button" />
 					<br />
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('vote', true);" class="button" />
@@ -179,6 +183,7 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %RATINGS_PERCENTAGE%</p>
+					<p style="margin: 2px 0">- %RATINGS_VOTE_TEXT%</p>
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('text', true);" class="button" /><br />
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('text', true);" class="button" />
 				</td>
@@ -194,6 +199,7 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %RATINGS_USERS%</p>
 					<p style="margin: 2px 0">- %RATINGS_AVERAGE%</p>
 					<p style="margin: 2px 0">- %RATINGS_PERCENTAGE%</p>
+					<p style="margin: 2px 0">- %RATINGS_VOTE_TEXT%</p>
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('permission', true);" class="button" /><br />
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('permission', true);" class="button" />
 				</td>
@@ -248,6 +254,7 @@ if ( isset( $_POST['Submit'] ) ) {
 					<p style="margin: 2px 0">- %POST_CONTENT%</p>
 					<p style="margin: 2px 0">- %POST_URL%</p>
 					<p style="margin: 2px 0">- %POST_THUMBNAIL%</p>
+					<p style="margin: 2px 0">- %RATINGS_VOTE_TEXT%</p>
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Normal Rating)', 'wp-postratings'); ?>" onclick="ratings_default_templates('mostrated', true);" class="button" /><br />
 					<input type="button" name="RestoreDefault" value="<?php esc_html_e('Restore Default Template (Up/Down Rating)', 'wp-postratings'); ?>" onclick="ratings_updown_templates('mostrated', true);" class="button" />
 				</td>

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,6 +25,8 @@ $option_names = array(
 	, 'postratings_options'
 	, 'widget_ratings'
 	, 'widget_ratings-widget'
+	, 'postratings_vote_text_singular'
+	, 'postratings_vote_text_plural'
 );
 
 

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1073,8 +1073,8 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
     $ratings_max = (int) get_option( 'postratings_max' );
     $ratings_custom = (int) get_option( 'postratings_customrating' );
     $ratings_options = get_option( 'postratings_options' );
-    $ratings_vote_text_singular = get_option('postratings_vote_text_singular');
-    $ratings_vote_text_plural = get_option('postratings_vote_text_plural');
+    $ratings_vote_text_singular = get_option('postratings_vote_text_singular', 'vote');
+    $ratings_vote_text_plural = get_option('postratings_vote_text_plural', 'votes');
 
     if ( is_object( $post_data ) ) {
         $post_id = (int) $post_data->ID;

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1073,6 +1073,8 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
     $ratings_max = (int) get_option( 'postratings_max' );
     $ratings_custom = (int) get_option( 'postratings_customrating' );
     $ratings_options = get_option( 'postratings_options' );
+    $ratings_vote_text_singular = get_option('postratings_vote_text_singular');
+    $ratings_vote_text_plural = get_option('postratings_vote_text_plural');
 
     if ( is_object( $post_data ) ) {
         $post_id = (int) $post_data->ID;
@@ -1149,6 +1151,11 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
     $value = str_replace("%RATINGS_AVERAGE%", number_format_i18n($post_ratings_average, 2), $value);
     $value = str_replace("%RATINGS_PERCENTAGE%", number_format_i18n($post_ratings_percentage, 2), $value);
     $value = str_replace("%RATINGS_USERS%", number_format_i18n($post_ratings_users), $value);
+    if ($post_ratings_users > 1) {
+        $value = str_replace("%RATINGS_VOTE_TEXT%", $ratings_vote_text_plural, $value);
+    } else {
+        $value = str_replace("%RATINGS_VOTE_TEXT%", $ratings_vote_text_singular, $value);
+    }    
 
     // Post Template Variables
     $post_link = get_permalink($post_data);


### PR DESCRIPTION
Hi Lester! First of all, thanks for the plugin. I know it's a bit dated, but still works great. :+1: 

Recently I needed a feature that was mentioned on #21, so I thought about opening this PR.

With this changes, you can set custom vote texts for singular words as well as plural words on the Options Page (it defaults to 'vote/votes'). It implements a new token (%RATINGS_VOTE_TEXT%) so that it can be replaced with the correct value, given the number of ratings.

I've also replaced all the custom default templates that had the word 'votes' with the new token.