### PR TITLE
Add Yoast SEO overrides

### DIFF
--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1163,7 +1163,11 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
 
 	// Post Template Variables
 	$post_link = get_permalink( $post_data );
-	$post_title = get_the_title( $post_data );
+	if ((get_post_meta($post->ID, ‘_yoast_wpseo_title’, true)) == “”) {
+		$post_title = get_the_title($post_data);
+	} else {
+		$post_title = get_post_meta($post_id, ‘_yoast_wpseo_title’, true);
+	}
 	if ( $max_post_title_chars > 0 ) {
 		$post_title = snippet_text( $post_title, $max_post_title_chars );
 	}
@@ -1195,6 +1199,10 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
 			$post = &get_post( $post_id );
 		}
 		$value = str_replace( '%POST_THUMBNAIL%', get_the_post_thumbnail( $post, 'thumbnail' ), $value );
+	}
+	
+	if (get_post_meta(get_the_ID(), ‘_yoast_wpseo_metadesc’, true) <> “”) {
+		$post_excerpt = get_post_meta(get_the_ID(), ‘_yoast_wpseo_metadesc’, true);
 	}
 
 	// Google Rich Snippet

--- a/wp-postratings.php
+++ b/wp-postratings.php
@@ -1163,10 +1163,10 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
 
 	// Post Template Variables
 	$post_link = get_permalink( $post_data );
-	if ((get_post_meta($post->ID, ‘_yoast_wpseo_title’, true)) == “”) {
+	if ((get_post_meta($post_id, '_yoast_wpseo_title', true)) == “”) {
 		$post_title = get_the_title($post_data);
 	} else {
-		$post_title = get_post_meta($post_id, ‘_yoast_wpseo_title’, true);
+		$post_title = get_post_meta($post_id, '_yoast_wpseo_title', true);
 	}
 	if ( $max_post_title_chars > 0 ) {
 		$post_title = snippet_text( $post_title, $max_post_title_chars );
@@ -1201,8 +1201,8 @@ function expand_ratings_template($template, $post_data, $post_ratings_data = nul
 		$value = str_replace( '%POST_THUMBNAIL%', get_the_post_thumbnail( $post, 'thumbnail' ), $value );
 	}
 	
-	if (get_post_meta(get_the_ID(), ‘_yoast_wpseo_metadesc’, true) <> “”) {
-		$post_excerpt = get_post_meta(get_the_ID(), ‘_yoast_wpseo_metadesc’, true);
+	if (get_post_meta($post_id, '_yoast_wpseo_metadesc', true) <> “”) {
+		$post_excerpt = get_post_meta($post_id, '_yoast_wpseo_metadesc', true);
 	}
 
 	// Google Rich Snippet


### PR DESCRIPTION
Add Yoast SEO overrides for title and meta description.

Yoast provides the option to have, in addition tot he post title, a SEO title. More info can be found here: https://yoast.com/whats-the-difference-between-an-h1-heading-and-the-seo-title/

Yoast SEO saves its post meta keys in _yoast_wpseo_metadesc and _yoast_wpseo_title. These are set by the SEO Snippet which allows for a better SEO title than the post title. By default, it puts this in the <title> tag of the <head> section and publishes it in the various og: meta properties.

The wp-postratings Rich Snippet conflicts with this, as it pulls uses the existing title and default generated meta description.

This PR overrides the title/description with Yoast ones if they exist.