### PR TITLE
Fixed Google Rich Snippets setting default value

### DIFF
--- a/postratings-options.php
+++ b/postratings-options.php
@@ -114,6 +114,10 @@ if ( isset( $_POST['Submit'] ) ) {
 ### Needed Variables
 $postratings_max = (int) get_option( 'postratings_max' );
 $postratings_options = get_option( 'postratings_options' );
+
+### enable rich snippets by default
+$postratings_options['richsnippet'] = isset( $postratings_options['richsnippet'] ) ? $postratings_options['richsnippet'] : 1;
+
 $postratings_customrating = (int) get_option( 'postratings_customrating' );
 $postratings_url = plugins_url( 'wp-postratings/images' );
 $postratings_path = WP_PLUGIN_DIR . '/wp-postratings/images';


### PR DESCRIPTION
Fixed Google Rich Snippets is shown as disabled by default when it is in fact enabled by default.

in wp-postratings.php line 1203:

```
$ratings_options['richsnippet']` = isset( $ratings_options['richsnippet'] ) ? $ratings_options['richsnippet']` : 1;
```

if $ratings_options['richsnippet'] is not set, it will be set to 1 / true which will show the richsnippet.

In postratings-options.php line 116, the same logic must be applied for the setting to reflect whether or not the richsnippet added to the code.

The problem only occurs when the setting was never changed from the default value thus never stored in the options.
